### PR TITLE
feat: add synonym support for keywords and cities

### DIFF
--- a/src/components/categories/CategoriesManager.tsx
+++ b/src/components/categories/CategoriesManager.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, DragStartEvent, DragEndEvent, DragOverEvent, DragOverlay } from '@dnd-kit/core'
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useToast } from '@/hooks/useToast'
-import { Category, CategoryGroup, CategoryKeyword } from '@/types'
+import { Category, CategoryGroup, CategoryKeywordWithSynonyms } from '@/types'
 import { moveCategoryToGroup, updateGroupOrder, updateCategoryOrderInGroup } from '@/lib/actions/categories'
 import { getAllKeywords } from '@/lib/actions/keywords'
 import { getUserSettings, UserSettings } from '@/lib/actions/settings'
@@ -69,7 +69,7 @@ const buildGroupsWithCategories = (allGroups: CategoryGroup[], allCategories: Ca
 export function CategoriesManager({ initialGroups, initialCategories }: CategoriesManagerProps) {
   const [groups, setGroups] = useState<CategoryGroupWithCategories[]>(() => buildGroupsWithCategories(initialGroups, initialCategories))
   const [categories, setCategories] = useState<Category[]>(initialCategories)
-  const [allKeywords, setAllKeywords] = useState<CategoryKeyword[]>([]);
+  const [allKeywords, setAllKeywords] = useState<CategoryKeywordWithSynonyms[]>([]);
   const [userSettings, setUserSettings] = useState<UserSettings>({});
   const [activeGroup, setActiveGroup] = useState<CategoryGroup | null>(null)
   const [activeCategory, setActiveCategory] = useState<Category | null>(null)

--- a/src/components/expense-input/bulk-input/BulkExpenseInput.tsx
+++ b/src/components/expense-input/bulk-input/BulkExpenseInput.tsx
@@ -17,6 +17,7 @@ import { extractCityFromDescription } from '@/lib/utils/cityParser'
 import type { Category, CreateExpenseData, ColumnMapping } from '@/types'
 import type { BulkExpenseRowData } from '@/lib/validations/expenses'
 import type { TableInfo } from '@/lib/utils/bankStatementParsers'
+import { useCitySynonyms } from '@/hooks/useCitySynonyms'
 
 interface BulkExpenseInputProps {
   categories: Category[]
@@ -40,6 +41,7 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
   const { showToast } = useToast()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
+  useCitySynonyms()
 
   // Загрузка сохраненной схемы столбцов при инициализации
   const loadSavedColumnMapping = useCallback(() => {
@@ -288,7 +290,8 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
           if (cityParseResult.confidence > 0.6) {
             cleanDescription = cityParseResult.cleanDescription
             if (cityParseResult.city) {
-              const cityNote = `Город: ${cityParseResult.city}`
+              const cityLabel = cityParseResult.displayCity || cityParseResult.city
+              const cityNote = `Город: ${cityLabel}`
               notes = notes ? `${notes}\n${cityNote}` : cityNote
             }
           }
@@ -370,7 +373,8 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
           if (cityParseResult.confidence > 0.6) {
             cleanDescription = cityParseResult.cleanDescription
             if (cityParseResult.city) {
-              const cityNote = `Город: ${cityParseResult.city}`
+              const cityLabel = cityParseResult.displayCity || cityParseResult.city
+              const cityNote = `Город: ${cityLabel}`
               notes = notes ? `${notes}\n${cityNote}` : cityNote
             }
           }

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Modal, Button, useToast, Input, Switch } from '@/components/ui'
 import { deleteAllUserData, getUserSettings, updateUserSettings, UserSettings } from '@/lib/actions/settings';
+import { CitySynonymManager } from '@/components/settings/CitySynonymManager';
 import { SelectiveDeleteModal } from './SelectiveDeleteModal';
 
 interface SettingsModalProps {
@@ -94,6 +95,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           {/* General Settings */}
           <div className="space-y-4">
             <h4 className="text-lg font-medium text-gray-900">Общие настройки</h4>
+            <CitySynonymManager />
           </div>
 
           {/* Danger Zone */}

--- a/src/components/settings/CitySynonymManager.tsx
+++ b/src/components/settings/CitySynonymManager.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Card, Button, Input } from '@/components/ui'
+import { useToast } from '@/hooks/useToast'
+import { getCitySynonyms, createCitySynonym, deleteCitySynonym } from '@/lib/actions/synonyms'
+import { syncCitySynonyms } from '@/lib/utils/cityParser'
+import type { CitySynonym } from '@/types'
+
+interface SynonymFormState {
+  city: string
+  synonym: string
+}
+
+export function CitySynonymManager() {
+  const [synonyms, setSynonyms] = useState<CitySynonym[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [formState, setFormState] = useState<SynonymFormState>({ city: '', synonym: '' })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [deletingMap, setDeletingMap] = useState<Record<string, boolean>>({})
+  const { showToast } = useToast()
+
+  const loadSynonyms = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = await getCitySynonyms()
+      if (result.error) {
+        showToast(result.error, 'error')
+      } else if (result.success && result.data) {
+        setSynonyms(result.data)
+        syncCitySynonyms(result.data.map(record => ({ city: record.city, synonym: record.synonym })))
+      }
+    } catch (error) {
+      console.error('Failed to load city synonyms', error)
+      showToast('Не удалось загрузить синонимы городов', 'error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [showToast])
+
+  useEffect(() => {
+    loadSynonyms()
+  }, [loadSynonyms])
+
+  const groupedSynonyms = useMemo(() => {
+    const map = new Map<string, CitySynonym[]>()
+    synonyms.forEach(record => {
+      const cityKey = record.city.trim() || 'Без города'
+      if (!map.has(cityKey)) {
+        map.set(cityKey, [])
+      }
+      map.get(cityKey)!.push(record)
+    })
+    return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0], 'ru'))
+  }, [synonyms])
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!formState.city.trim() || !formState.synonym.trim()) {
+      showToast('Заполните оба поля', 'error')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const result = await createCitySynonym({ city: formState.city.trim(), synonym: formState.synonym.trim() })
+      if (result.error) {
+        showToast(result.error, 'error')
+      } else if (result.success && result.data) {
+        setSynonyms(prev => {
+          const updated = [...prev, result.data]
+          syncCitySynonyms(updated.map(record => ({ city: record.city, synonym: record.synonym })))
+          return updated
+        })
+        showToast('Синоним города добавлен', 'success')
+        setFormState({ city: '', synonym: '' })
+      }
+    } catch (error) {
+      console.error('Failed to create city synonym', error)
+      showToast('Не удалось добавить синоним города', 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (synonym: CitySynonym) => {
+    setDeletingMap(prev => ({ ...prev, [synonym.id]: true }))
+    try {
+      const result = await deleteCitySynonym({ id: synonym.id })
+      if (result.error) {
+        showToast(result.error, 'error')
+      } else {
+        setSynonyms(prev => {
+          const updated = prev.filter(item => item.id !== synonym.id)
+          syncCitySynonyms(updated.map(record => ({ city: record.city, synonym: record.synonym })))
+          return updated
+        })
+        showToast('Синоним удален', 'success')
+      }
+    } catch (error) {
+      console.error('Failed to delete city synonym', error)
+      showToast('Не удалось удалить синоним', 'error')
+    } finally {
+      setDeletingMap(prev => ({ ...prev, [synonym.id]: false }))
+    }
+  }
+
+  return (
+    <Card className="p-6 space-y-6">
+      <div>
+        <h5 className="text-base font-semibold text-gray-900">Синонимы городов</h5>
+        <p className="text-sm text-gray-500 mt-1">
+          Добавьте альтернативные написания городов, чтобы объединять их в аналитике и заметках. При совпадении будет отображаться
+          основной город и использованный синоним.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="grid gap-3 md:grid-cols-3">
+        <div className="md:col-span-1">
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="synonym-city">Главный город</label>
+          <Input
+            id="synonym-city"
+            placeholder="Например: Минск"
+            value={formState.city}
+            onChange={(event) => setFormState(prev => ({ ...prev, city: event.target.value }))}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="md:col-span-1">
+          <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="synonym-alias">Синоним</label>
+          <Input
+            id="synonym-alias"
+            placeholder="Например: Minsk"
+            value={formState.synonym}
+            onChange={(event) => setFormState(prev => ({ ...prev, synonym: event.target.value }))}
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="md:col-span-1 flex items-end">
+          <Button type="submit" isLoading={isSubmitting} className="w-full md:w-auto">
+            Добавить синоним
+          </Button>
+        </div>
+      </form>
+
+      <div className="space-y-4">
+        {isLoading ? (
+          <div className="text-sm text-gray-500">Загрузка синонимов...</div>
+        ) : groupedSynonyms.length === 0 ? (
+          <div className="text-sm text-gray-500">Пока нет ни одного синонима города.</div>
+        ) : (
+          groupedSynonyms.map(([city, entries]) => (
+            <div key={city} className="border border-gray-200 rounded-lg p-4 space-y-3">
+              <div className="text-sm font-semibold text-gray-800">{city}</div>
+              <div className="flex flex-wrap gap-2">
+                {entries.map(entry => (
+                  <span key={entry.id} className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 rounded-full px-3 py-1 text-xs">
+                    {entry.synonym}
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(entry)}
+                      className="hover:text-red-600 focus:outline-none"
+                      disabled={!!deletingMap[entry.id] || isSubmitting}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/src/hooks/useCitySynonyms.ts
+++ b/src/hooks/useCitySynonyms.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getCitySynonyms } from '@/lib/actions/synonyms'
+import { syncCitySynonyms } from '@/lib/utils/cityParser'
+import type { CitySynonym } from '@/types'
+
+export function useCitySynonyms() {
+  const [synonyms, setSynonyms] = useState<CitySynonym[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      try {
+        const result = await getCitySynonyms()
+        if (!isMounted) {
+          return
+        }
+
+        if (result.success && result.data) {
+          setSynonyms(result.data)
+          syncCitySynonyms(result.data.map(record => ({ city: record.city, synonym: record.synonym })))
+        }
+      } catch (error) {
+        console.error('Failed to preload city synonyms', error)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return { synonyms, isLoading }
+}

--- a/src/lib/actions/synonyms.ts
+++ b/src/lib/actions/synonyms.ts
@@ -1,0 +1,217 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createServerClient } from '@/lib/supabase/server'
+import {
+  keywordSynonymSchema,
+  deleteKeywordSynonymSchema,
+  citySynonymSchema,
+  deleteCitySynonymSchema,
+  type CreateKeywordSynonymData,
+  type DeleteKeywordSynonymData,
+  type CreateCitySynonymData,
+  type DeleteCitySynonymData
+} from '@/lib/validations/synonyms'
+import type { KeywordSynonym, CitySynonym } from '@/types'
+
+export async function getKeywordSynonyms(keywordId: string) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const { data, error } = await supabase
+      .from('keyword_synonyms')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('keyword_id', keywordId)
+      .order('created_at', { ascending: true })
+
+    if (error) {
+      console.error('Ошибка загрузки синонимов ключевого слова:', error)
+      return { error: 'Не удалось загрузить синонимы' }
+    }
+
+    return { success: true, data: (data || []) as KeywordSynonym[] }
+  } catch (err) {
+    console.error('Ошибка получения синонимов ключевого слова:', err)
+    return { error: 'Произошла ошибка при загрузке синонимов' }
+  }
+}
+
+export async function createKeywordSynonym(data: CreateKeywordSynonymData) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = keywordSynonymSchema.parse(data)
+
+    const { data: keyword, error: keywordError } = await supabase
+      .from('category_keywords')
+      .select('id, user_id')
+      .eq('id', validated.keyword_id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (keywordError || !keyword) {
+      return { error: 'Ключевое слово не найдено' }
+    }
+
+    const { data: synonym, error } = await supabase
+      .from('keyword_synonyms')
+      .insert({
+        keyword_id: validated.keyword_id,
+        synonym: validated.synonym.trim(),
+        user_id: user.id
+      })
+      .select()
+      .single()
+
+    if (error) {
+      if (error.code === '23505') {
+        return { error: 'Такой синоним уже существует' }
+      }
+      console.error('Ошибка создания синонима ключевого слова:', error)
+      return { error: 'Не удалось создать синоним' }
+    }
+
+    revalidatePath('/categories')
+    return { success: true, data: synonym as KeywordSynonym }
+  } catch (err) {
+    console.error('Ошибка добавления синонима ключевого слова:', err)
+    return { error: 'Произошла ошибка при создании синонима' }
+  }
+}
+
+export async function deleteKeywordSynonym(data: DeleteKeywordSynonymData) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = deleteKeywordSynonymSchema.parse(data)
+
+    const { error } = await supabase
+      .from('keyword_synonyms')
+      .delete()
+      .eq('id', validated.id)
+      .eq('keyword_id', validated.keyword_id)
+      .eq('user_id', user.id)
+
+    if (error) {
+      console.error('Ошибка удаления синонима ключевого слова:', error)
+      return { error: 'Не удалось удалить синоним' }
+    }
+
+    revalidatePath('/categories')
+    return { success: true }
+  } catch (err) {
+    console.error('Ошибка удаления синонима ключевого слова:', err)
+    return { error: 'Произошла ошибка при удалении синонима' }
+  }
+}
+
+export async function getCitySynonyms() {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const { data, error } = await supabase
+      .from('city_synonyms')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('city', { ascending: true })
+      .order('synonym', { ascending: true })
+
+    if (error) {
+      console.error('Ошибка загрузки синонимов городов:', error)
+      return { error: 'Не удалось загрузить синонимы городов' }
+    }
+
+    return { success: true, data: (data || []) as CitySynonym[] }
+  } catch (err) {
+    console.error('Ошибка получения синонимов городов:', err)
+    return { error: 'Произошла ошибка при загрузке синонимов городов' }
+  }
+}
+
+export async function createCitySynonym(data: CreateCitySynonymData) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = citySynonymSchema.parse(data)
+
+    const { data: synonym, error } = await supabase
+      .from('city_synonyms')
+      .insert({
+        city: validated.city.trim(),
+        synonym: validated.synonym.trim(),
+        user_id: user.id
+      })
+      .select()
+      .single()
+
+    if (error) {
+      if (error.code === '23505') {
+        return { error: 'Такой синоним города уже существует' }
+      }
+      console.error('Ошибка создания синонима города:', error)
+      return { error: 'Не удалось создать синоним города' }
+    }
+
+    revalidatePath('/settings')
+    return { success: true, data: synonym as CitySynonym }
+  } catch (err) {
+    console.error('Ошибка добавления синонима города:', err)
+    return { error: 'Произошла ошибка при создании синонима города' }
+  }
+}
+
+export async function deleteCitySynonym(data: DeleteCitySynonymData) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = deleteCitySynonymSchema.parse(data)
+
+    const { error } = await supabase
+      .from('city_synonyms')
+      .delete()
+      .eq('id', validated.id)
+      .eq('user_id', user.id)
+
+    if (error) {
+      console.error('Ошибка удаления синонима города:', error)
+      return { error: 'Не удалось удалить синоним города' }
+    }
+
+    revalidatePath('/settings')
+    return { success: true }
+  } catch (err) {
+    console.error('Ошибка удаления синонима города:', err)
+    return { error: 'Произошла ошибка при удалении синонима города' }
+  }
+}

--- a/src/lib/validations/synonyms.ts
+++ b/src/lib/validations/synonyms.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+export const keywordSynonymSchema = z.object({
+  keyword_id: z.string().uuid('Некорректный идентификатор ключевого слова'),
+  synonym: z.string().min(2, 'Синоним должен содержать минимум 2 символа').max(100, 'Синоним слишком длинный')
+})
+
+export const deleteKeywordSynonymSchema = z.object({
+  id: z.string().uuid('Некорректный идентификатор синонима'),
+  keyword_id: z.string().uuid('Некорректный идентификатор ключевого слова')
+})
+
+export const citySynonymSchema = z.object({
+  city: z.string().min(2, 'Название города должно содержать минимум 2 символа').max(100, 'Название города слишком длинное'),
+  synonym: z.string().min(2, 'Синоним должен содержать минимум 2 символа').max(100, 'Синоним слишком длинный')
+})
+
+export const deleteCitySynonymSchema = z.object({
+  id: z.string().uuid('Некорректный идентификатор записи синонима')
+})
+
+export type CreateKeywordSynonymData = z.infer<typeof keywordSynonymSchema>
+export type DeleteKeywordSynonymData = z.infer<typeof deleteKeywordSynonymSchema>
+export type CreateCitySynonymData = z.infer<typeof citySynonymSchema>
+export type DeleteCitySynonymData = z.infer<typeof deleteCitySynonymSchema>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,29 @@ export type Database = {
           user_id?: string | null
         }
       }
+      keyword_synonyms: {
+        Row: {
+          created_at: string | null
+          id: string
+          keyword_id: string
+          synonym: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          keyword_id: string
+          synonym: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          keyword_id?: string
+          synonym?: string
+          user_id?: string | null
+        }
+      }
       expenses: {
         Row: {
           amount: number
@@ -195,6 +218,29 @@ export type Database = {
           user_id?: string | null
         }
       }
+      city_synonyms: {
+        Row: {
+          city: string
+          created_at: string | null
+          id: string
+          synonym: string
+          user_id: string | null
+        }
+        Insert: {
+          city: string
+          created_at?: string | null
+          id?: string
+          synonym: string
+          user_id?: string | null
+        }
+        Update: {
+          city?: string
+          created_at?: string | null
+          id?: string
+          synonym?: string
+          user_id?: string | null
+        }
+      }
     }
   }
 }
@@ -205,7 +251,13 @@ export type CategoryGroup = Database['public']['Tables']['category_groups']['Row
 export type Expense = Database['public']['Tables']['expenses']['Row']
 
 export type CategoryKeyword = Database['public']['Tables']['category_keywords']['Row']
+export type KeywordSynonym = Database['public']['Tables']['keyword_synonyms']['Row']
 export type UnrecognizedKeyword = Database['public']['Tables']['unrecognized_keywords']['Row']
+export type CitySynonym = Database['public']['Tables']['city_synonyms']['Row']
+
+export type CategoryKeywordWithSynonyms = CategoryKeyword & {
+  keyword_synonyms?: KeywordSynonym[]
+}
 
 export type ExpenseWithCategory = Expense & {
   category: Category | null


### PR DESCRIPTION
## Summary
- add Supabase actions and validation to manage keyword and city synonyms
- extend keyword editor with synonym management UI and introduce a city synonym manager in settings
- enhance categorization logic and city parser to respect synonyms, updating hooks, tests, and types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfc35fba148320a9686d25467254d5