### PR TITLE
fix: resolve keyword synonym typing for bulk categorization

### DIFF
--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -328,7 +328,13 @@ export async function createBulkExpenses(expenses: CreateExpenseData[]) {
 
       const descriptionLower = description.toLowerCase()
 
-      for (const keyword of keywords as (typeof keywords)[number] & { keyword_synonyms?: { synonym: string }[] }) {
+      const keywordList = (keywords ?? []) as Array<
+        (typeof keywords extends Array<infer Item> ? Item : never) & {
+          keyword_synonyms?: { synonym: string | null }[]
+        }
+      >
+
+      for (const keyword of keywordList) {
         const base = keyword.keyword?.toLowerCase()
         if (base && descriptionLower.includes(base)) {
           return {


### PR DESCRIPTION
## Summary
- ensure the bulk categorization helper iterates over a safely typed keyword list
- allow synonyms to include null-safe strings when performing comparisons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfd131ece083209a99cdd8a4003671