### PR TITLE
Simplify city management view and add interactive map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,11 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/d3-geo": "^3.1.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/topojson-client": "^3.1.5",
         "autoprefixer": "^10.4.21",
         "eslint": "^8",
         "eslint-config-next": "15.4.6",
@@ -1544,6 +1546,23 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1584,6 +1603,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,13 @@
         "@supabase/ssr": "^0.1.0",
         "@supabase/supabase-js": "^2.39.0",
         "clsx": "^2.1.0",
+        "d3-geo": "^3.1.1",
         "next": "15.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^2.2.0",
+        "topojson-client": "^3.1.0",
+        "world-atlas": "^2.0.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -2886,6 +2889,30 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4301,6 +4328,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6853,6 +6889,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -7297,6 +7353,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
     "@supabase/ssr": "^0.1.0",
     "@supabase/supabase-js": "^2.39.0",
     "clsx": "^2.1.0",
+    "d3-geo": "^3.1.1",
     "next": "15.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.2.0",
+    "topojson-client": "^3.1.0",
+    "world-atlas": "^2.0.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/d3-geo": "^3.1.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/topojson-client": "^3.1.5",
     "autoprefixer": "^10.4.21",
     "eslint": "^8",
     "eslint-config-next": "15.4.6",

--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -3,15 +3,15 @@ import { StickyPageHeaderWrapper } from '@/components/layout/StickyPageHeaderWra
 
 export default function CitiesPage() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-slate-50">
       <StickyPageHeaderWrapper
         title="Города и синонимы"
-        description="Управляйте городами и их синонимами для лучшей аналитики."
+        description="Добавляйте новые города, связывайте разные написания и поддерживайте единый справочник."
       />
 
-      <div className="container mx-auto px-4 pt-4 pb-8">
+      <main className="container mx-auto px-4 pb-12 pt-6">
         <CitySynonymManager />
-      </div>
+      </main>
     </div>
   )
 }

--- a/src/components/settings/AddSynonymForm.tsx
+++ b/src/components/settings/AddSynonymForm.tsx
@@ -40,15 +40,15 @@ export function AddSynonymForm({ city, onSynonymAdded }: AddSynonymFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2 mt-2">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <Input
-        placeholder="Добавить синоним"
+        placeholder="Добавить альтернативное написание"
         value={synonym}
-        onChange={(e) => setSynonym(e.target.value)}
+        onChange={(event) => setSynonym(event.target.value)}
         disabled={isSubmitting}
-        className="h-8 text-xs"
+        className="h-10 flex-1 text-sm"
       />
-      <Button type="submit" isLoading={isSubmitting} size="sm" variant="outline">
+      <Button type="submit" isLoading={isSubmitting} size="sm" variant="outline" className="sm:w-auto">
         Добавить
       </Button>
     </form>

--- a/src/components/settings/CityMap.tsx
+++ b/src/components/settings/CityMap.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from 'react'
 import { geoMercator, geoPath } from 'd3-geo'
 import { feature } from 'topojson-client'
 import type { Feature, FeatureCollection, Geometry } from 'geojson'
+import type { GeometryCollection as TopologyGeometryCollection, Topology } from 'topojson-specification'
 import countries110m from 'world-atlas/countries-110m.json'
 
 const WIDTH = 760
@@ -72,9 +73,13 @@ const coordinateEntries: CoordinateEntry[] = [
 
 coordinateEntries.forEach(([names, lon, lat]) => addCoordinate(names, lon, lat))
 
+const countriesTopology = countries110m as unknown as Topology<{
+  countries: TopologyGeometryCollection
+}>
+
 const countries = feature(
-  countries110m as unknown as { type: 'Topology'; objects: { countries: unknown } },
-  (countries110m as unknown as { objects: { countries: unknown } }).objects.countries
+  countriesTopology,
+  countriesTopology.objects.countries as TopologyGeometryCollection
 ) as FeatureCollection<Geometry>
 
 const russiaFeature = countries.features.find(item => item.id === RUSSIA_ID) as Feature<Geometry> | undefined

--- a/src/components/settings/CityMap.tsx
+++ b/src/components/settings/CityMap.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { memo, useMemo } from 'react'
+import { geoMercator, geoPath } from 'd3-geo'
+import { feature } from 'topojson-client'
+import type { Feature, FeatureCollection, Geometry } from 'geojson'
+import countries110m from 'world-atlas/countries-110m.json'
+
+const WIDTH = 760
+const HEIGHT = 420
+const RUSSIA_ID = 643
+
+interface CityMapProps {
+  cities: { name: string; total: number; alternate: number }[]
+  activeCity: string | null
+  onSelectCity: (city: string) => void
+}
+
+interface Marker {
+  name: string
+  total: number
+  alternate: number
+  x: number
+  y: number
+  radius: number
+  hasCoordinates: boolean
+}
+
+const normaliseName = (value: string) => value.trim().toLowerCase()
+
+const coordinateLookup = new Map<string, { lon: number; lat: number }>()
+
+const addCoordinate = (names: string[], lon: number, lat: number) => {
+  names.forEach(name => {
+    coordinateLookup.set(normaliseName(name), { lon, lat })
+  })
+}
+
+type CoordinateEntry = [string[], number, number]
+
+const coordinateEntries: CoordinateEntry[] = [
+  [['Москва', 'Moscow', 'Msk'], 37.6173, 55.7558],
+  [['Санкт-Петербург', 'Saint Petersburg', 'Санкт Петербург', 'St Petersburg', 'СПб'], 30.3351, 59.9343],
+  [['Новосибирск', 'Novosibirsk'], 82.9204, 55.0302],
+  [['Екатеринбург', 'Ekaterinburg', 'Yekaterinburg'], 60.5975, 56.8389],
+  [['Казань', 'Kazan'], 49.1064, 55.7963],
+  [['Нижний Новгород', 'Nizhny Novgorod'], 44.002, 56.3269],
+  [['Челябинск', 'Chelyabinsk'], 61.4026, 55.1604],
+  [['Самара', 'Samara'], 50.1008, 53.1959],
+  [['Омск', 'Omsk'], 73.3682, 54.9893],
+  [['Ростов-на-Дону', 'Rostov-on-Don', 'Rostov na Donu'], 39.7203, 47.2357],
+  [['Уфа', 'Ufa'], 55.9678, 54.7388],
+  [['Красноярск', 'Krasnoyarsk'], 92.8526, 56.0106],
+  [['Пермь', 'Perm'], 56.2294, 58.0104],
+  [['Воронеж', 'Voronezh'], 39.2003, 51.6608],
+  [['Волгоград', 'Volgograd'], 44.5018, 48.708],
+  [['Саратов', 'Saratov'], 46.0333, 51.5336],
+  [['Краснодар', 'Krasnodar'], 38.9747, 45.0355],
+  [['Тюмень', 'Tyumen'], 65.5343, 57.153],
+  [['Томск', 'Tomsk'], 84.9744, 56.4847],
+  [['Иркутск', 'Irkutsk'], 104.296, 52.2869],
+  [['Якутск', 'Yakutsk'], 129.7326, 62.0355],
+  [['Владивосток', 'Vladivostok'], 131.8869, 43.1155],
+  [['Хабаровск', 'Khabarovsk'], 135.0719, 48.4827],
+  [['Калининград', 'Kaliningrad'], 20.492, 54.7104],
+  [['Барнаул', 'Barnaul'], 83.7689, 53.3481],
+  [['Сочи', 'Sochi'], 39.7303, 43.5855],
+  [['Ярославль', 'Yaroslavl'], 39.8938, 57.6266],
+  [['Белгород', 'Belgorod'], 36.5802, 50.5997],
+  [['Тула', 'Tula'], 37.6188, 54.1961]
+]
+
+coordinateEntries.forEach(([names, lon, lat]) => addCoordinate(names, lon, lat))
+
+const countries = feature(
+  countries110m as unknown as { type: 'Topology'; objects: { countries: unknown } },
+  (countries110m as unknown as { objects: { countries: unknown } }).objects.countries
+) as FeatureCollection<Geometry>
+
+const russiaFeature = countries.features.find(item => item.id === RUSSIA_ID) as Feature<Geometry> | undefined
+
+const CityMapComponent = ({ cities, activeCity, onSelectCity }: CityMapProps) => {
+  const projection = useMemo(() => {
+    const proj = geoMercator()
+    if (russiaFeature) {
+      proj.fitExtent(
+        [
+          [40, 30],
+          [WIDTH - 40, HEIGHT - 100]
+        ],
+        russiaFeature
+      )
+    } else {
+      proj.scale(450).translate([WIDTH / 2, HEIGHT / 2])
+    }
+    return proj
+  }, [])
+
+  const pathGenerator = useMemo(() => geoPath(projection), [projection])
+  const mapPath = useMemo(() => (russiaFeature ? pathGenerator(russiaFeature) : null), [pathGenerator])
+
+  const markers: Marker[] = useMemo(() => {
+    let fallbackIndex = 0
+    const fallbackColumns = 4
+    const fallbackStartX = 120
+    const fallbackStartY = HEIGHT - 60
+    const fallbackColumnSpacing = 140
+    const fallbackRowSpacing = 44
+
+    return cities.map(city => {
+      const key = normaliseName(city.name)
+      const coordinate = coordinateLookup.get(key)
+      let position: [number, number] | null = null
+      let hasCoordinates = false
+
+      if (coordinate) {
+        const projected = projection([coordinate.lon, coordinate.lat])
+        if (projected) {
+          position = projected as [number, number]
+          hasCoordinates = true
+        }
+      }
+
+      if (!position) {
+        const column = fallbackIndex % fallbackColumns
+        const row = Math.floor(fallbackIndex / fallbackColumns)
+        position = [
+          fallbackStartX + column * fallbackColumnSpacing,
+          fallbackStartY + row * fallbackRowSpacing
+        ]
+        fallbackIndex += 1
+      }
+
+      const radius = Math.min(6 + city.alternate * 2, 14)
+
+      return {
+        name: city.name,
+        total: city.total,
+        alternate: city.alternate,
+        x: position[0],
+        y: position[1],
+        radius,
+        hasCoordinates
+      }
+    })
+  }, [cities, projection])
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          className="h-[320px] w-full rounded-lg border border-slate-200 bg-slate-100"
+          role="img"
+          aria-label="Карта с расположением городов"
+        >
+          {mapPath ? (
+            <path d={mapPath} fill="#E2E8F0" stroke="#94A3B8" strokeWidth={1.2} />
+          ) : (
+            <rect x={40} y={40} width={WIDTH - 80} height={HEIGHT - 120} fill="#E2E8F0" stroke="#94A3B8" strokeWidth={1.2} />
+          )}
+        </svg>
+
+        {markers.map(marker => {
+          const left = `${(marker.x / WIDTH) * 100}%`
+          const top = `${(marker.y / HEIGHT) * 100}%`
+          const isActive = activeCity === marker.name
+          const label = `${marker.name}. Всего записей: ${marker.total}. Альтернативных написаний: ${marker.alternate}`
+
+          return (
+            <button
+              key={marker.name}
+              type="button"
+              onClick={() => onSelectCity(marker.name)}
+              className="group absolute -translate-x-1/2 -translate-y-1/2 transform"
+              style={{ left, top }}
+              aria-label={label}
+              aria-pressed={isActive}
+            >
+              <span
+                className={`flex items-center justify-center rounded-full border text-xs font-semibold transition ${
+                  isActive
+                    ? 'border-slate-900 bg-slate-900 text-white'
+                    : 'border-slate-400 bg-white text-slate-600 group-hover:border-slate-600 group-hover:text-slate-700'
+                }`}
+                style={{ width: `${marker.radius * 2}px`, height: `${marker.radius * 2}px` }}
+              >
+                {marker.alternate}
+              </span>
+              <span
+                className={`mt-1 block whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] transition ${
+                  isActive
+                    ? 'border-slate-900 bg-slate-900 text-white'
+                    : 'border-slate-200 bg-white text-slate-600 group-hover:border-slate-300 group-hover:text-slate-700'
+                }`}
+              >
+                {marker.name}
+                {!marker.hasCoordinates && ' *'}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+      <p className="text-xs text-slate-500">
+        Число в маркере показывает количество альтернативных написаний. Звёздочка рядом с названием означает приблизительное
+        расположение.
+      </p>
+    </div>
+  )
+}
+
+export const CityMap = memo(CityMapComponent)
+CityMap.displayName = 'CityMap'


### PR DESCRIPTION
## Summary
- replace the decorative hero on the cities page with a clean layout that keeps the focus on data
- streamline the city synonym manager UI while preserving add/search/delete flows and stats
- introduce an interactive CityMap component that visualises filtered cities and highlights selections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02c2c11a4832088177eb23871c23e