### PR TITLE
Remove city autocomplete and add city management

### DIFF
--- a/src/lib/validations/synonyms.ts
+++ b/src/lib/validations/synonyms.ts
@@ -19,7 +19,18 @@ export const deleteCitySynonymSchema = z.object({
   id: z.string().uuid('Некорректный идентификатор записи синонима')
 })
 
+export const updateCitySchema = z.object({
+  id: z.string().uuid('Некорректный идентификатор записи синонима'),
+  city: z.string().min(2, 'Название города должно содержать минимум 2 символа').max(100, 'Название города слишком длинное')
+})
+
+export const deleteCitySchema = z.object({
+  id: z.string().uuid('Некорректный идентификатор записи синонима')
+})
+
 export type CreateKeywordSynonymData = z.infer<typeof keywordSynonymSchema>
 export type DeleteKeywordSynonymData = z.infer<typeof deleteKeywordSynonymSchema>
 export type CreateCitySynonymData = z.infer<typeof citySynonymSchema>
 export type DeleteCitySynonymData = z.infer<typeof deleteCitySynonymSchema>
+export type UpdateCityData = z.infer<typeof updateCitySchema>
+export type DeleteCityData = z.infer<typeof deleteCitySchema>


### PR DESCRIPTION
## Summary
- remove the city search autocomplete from the cities management page and simplify the header actions
- add inline city rename support with confirmation-based delete flows and updated UI controls
- expose server actions and validations to rename or delete a city across all synonyms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0706e49ec8320a2bd5233c191ab06