### PR TITLE
Fix city synonym flow to use city IDs

### DIFF
--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -1,17 +1,53 @@
-import { CitySynonymManager } from '@/components/settings/CitySynonymManager'
-import { StickyPageHeaderWrapper } from '@/components/layout/StickyPageHeaderWrapper'
-
+// src/app/(dashboard)/cities/page.tsx
+'use client'; // Временно делаем страницу клиентской для простоты
+import { StickyPageHeader } from '@/components/layout/StickyPageHeader';
+import { CitySynonymManager } from '@/components/settings/CitySynonymManager';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
+import { YMaps, Map } from '@pbe/react-yandex-maps';
+// На этом шаге мы используем 'use client' для простоты.
+// На следующих шагах мы вернемся к серверному компоненту.
 export default function CitiesPage() {
+  const yandexApiKey = process.env.NEXT_PUBLIC_YANDEX_MAPS_API_KEY;
+  const mapState = {
+    center: [55.75, 37.62], // Центр Москвы
+    zoom: 4,
+  };
   return (
     <div className="min-h-screen bg-slate-50">
-      <StickyPageHeaderWrapper
+      <StickyPageHeader
         title="Города и синонимы"
-        description="Добавляйте новые города, связывайте разные написания и поддерживайте единый справочник."
+        description="Управляйте городами и анализируйте географию ваших расходов."
       />
-
-      <main className="container mx-auto px-4 pb-12 pt-6">
-        <CitySynonymManager />
+      <main className="container mx-auto grid grid-cols-1 gap-6 px-4 pb-12 pt-6 lg:grid-cols-2">
+        {/* Левая колонка - Карта */}
+        <div className="lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Карта расходов</CardTitle>
+              <CardDescription>
+                Визуализация городов, в которых вы совершали траты.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="h-[400px] w-full overflow-hidden rounded-lg border">
+                {yandexApiKey ? (
+                  <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
+                    <Map state={mapState} width="100%" height="100%" />
+                  </YMaps>
+                ) : (
+                  <div className="flex h-full items-center justify-center bg-red-50 text-red-700">
+                    Ошибка: API-ключ для Яндекс Карт не настроен.
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        {/* Правая колонка - Менеджер синонимов */}
+        <div className="lg:col-span-1">
+          <CitySynonymManager />
+        </div>
       </main>
     </div>
-  )
+  );
 }

--- a/src/components/expense-input/ExpenseForm.tsx
+++ b/src/components/expense-input/ExpenseForm.tsx
@@ -48,7 +48,7 @@ export function ExpenseForm({
     notes: defaultValues?.notes || '',
     expense_date: defaultValues?.expense_date || getCurrentDateISO(),
     expense_time: defaultValues?.expense_time || '',
-    city: defaultValues?.city || '',
+    city: defaultValues?.city_id || '',
     input_method: 'single' as const
   })
 
@@ -166,6 +166,7 @@ export function ExpenseForm({
           notes: formData.notes || undefined,
           expense_date: formData.expense_date,
           expense_time: formData.expense_time || undefined,
+          city_id: formData.city || undefined,
           input_method: formData.input_method
           // category_id не указываем - система автоматически определит или поместит в неопознанные
         }

--- a/src/components/expense-input/QuickExpenseForm.tsx
+++ b/src/components/expense-input/QuickExpenseForm.tsx
@@ -75,7 +75,7 @@ export function QuickExpenseForm({
           notes: formData.notes || undefined,
           expense_date: formData.expense_date,
           expense_time: formData.expense_time || undefined,
-          city: formData.city || undefined,
+          city_id: formData.city || undefined,
           input_method: formData.input_method
           // category_id не указываем - система автоматически определит
         }

--- a/src/components/expenses/InlineNotesEditor.tsx
+++ b/src/components/expenses/InlineNotesEditor.tsx
@@ -60,6 +60,11 @@ export function InlineNotesEditor({ expense, onUpdate }: InlineNotesEditorProps)
           return
         }
 
+        if (!result.data) {
+          showToast('Не удалось обновить примечание', 'error')
+          return
+        }
+
         onUpdate(result.data)
         setIsEditing(false)
         showToast('Примечание обновлено', 'success')

--- a/src/components/settings/AddSynonymForm.tsx
+++ b/src/components/settings/AddSynonymForm.tsx
@@ -6,11 +6,12 @@ import { useToast } from '@/hooks/useToast'
 import { createCitySynonym } from '@/lib/actions/synonyms'
 
 interface AddSynonymFormProps {
-  city: string
+  cityId: string
+  cityName: string
   onSynonymAdded: () => void
 }
 
-export function AddSynonymForm({ city, onSynonymAdded }: AddSynonymFormProps) {
+export function AddSynonymForm({ cityId, cityName, onSynonymAdded }: AddSynonymFormProps) {
   const [synonym, setSynonym] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { showToast } = useToast()
@@ -24,7 +25,7 @@ export function AddSynonymForm({ city, onSynonymAdded }: AddSynonymFormProps) {
 
     setIsSubmitting(true)
     try {
-      const result = await createCitySynonym({ city, synonym: synonym.trim() })
+      const result = await createCitySynonym({ cityId, synonym: synonym.trim() })
       if (result.error) {
         showToast(result.error, 'error')
       } else {
@@ -42,7 +43,7 @@ export function AddSynonymForm({ city, onSynonymAdded }: AddSynonymFormProps) {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <Input
-        placeholder="Добавить альтернативное написание"
+        placeholder={`Добавить альтернативное написание для «${cityName}»`}
         value={synonym}
         onChange={(event) => setSynonym(event.target.value)}
         disabled={isSubmitting}

--- a/src/lib/actions/settings.ts
+++ b/src/lib/actions/settings.ts
@@ -123,8 +123,17 @@ export async function deleteAllUserData() {
   try {
     const deletedItems: string[] = []
 
+    type SupabaseTable =
+      | 'expenses'
+      | 'keyword_synonyms'
+      | 'unrecognized_keywords'
+      | 'category_keywords'
+      | 'city_synonyms'
+      | 'categories'
+      | 'category_groups'
+
     const deleteWithCheck = async (
-      table: string,
+      table: SupabaseTable,
       description: string,
       message?: string,
     ) => {

--- a/src/lib/validations/synonyms.ts
+++ b/src/lib/validations/synonyms.ts
@@ -11,12 +11,23 @@ export const deleteKeywordSynonymSchema = z.object({
 });
 
 export const citySynonymSchema = z.object({
-  city: z.string().min(2, 'Название города должно содержать минимум 2 символа').max(100, 'Название города слишком длинное'),
+  cityId: z.string().uuid('Некорректный идентификатор города').optional(),
+  city: z
+    .string()
+    .min(2, 'Название города должно содержать минимум 2 символа')
+    .max(100, 'Название города слишком длинное')
+    .optional(),
   synonym: z.string().min(2, 'Синоним должен содержать минимум 2 символа').max(100, 'Синоним слишком длинный')
+}).refine((data) => data.cityId || data.city, {
+  message: 'Укажите город или идентификатор города',
+  path: ['city']
 });
 
 export const deleteCitySynonymSchema = z.object({
-  id: z.string().uuid('Некорректный идентификатор записи синонима')
+  id: z.union([
+    z.number().int('Некорректный идентификатор записи синонима'),
+    z.string().regex(/^\d+$/, 'Некорректный идентификатор записи синонима')
+  ])
 });
 
 export const deleteCitySchema = z.object({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -498,6 +498,7 @@ export type Expense = Database['public']['Tables']['expenses']['Row']
 export type City = Database['public']['Tables']['cities']['Row']
 export type CityAlias = Database['public']['Tables']['city_aliases']['Row']
 export type CitySynonym = Database['public']['Tables']['city_synonyms']['Row']
+export type CitySynonymWithCity = CitySynonym & { city: Pick<City, 'id' | 'name'> | null }
 export type UnrecognizedCity = Database['public']['Tables']['unrecognized_cities']['Row']
 
 export type CategoryKeyword = Database['public']['Tables']['category_keywords']['Row']


### PR DESCRIPTION
## Summary
- align city synonym server actions and validations with the `city_id` foreign key and return city metadata for UI consumers
- normalise the city synonym manager, add form, and preload hook to work with city IDs, update grouping and state updates, and keep client-side caches in sync
- expose a reusable `CitySynonymWithCity` type for joined records

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d18452c3a48320adbd884f625aee84