### PR TITLE
Refine city dictionary layout and coordinate workflow

### DIFF
--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -18,35 +18,30 @@ export default function CitiesPage() {
         title="Города и синонимы"
         description="Управляйте городами и анализируйте географию ваших расходов."
       />
-      <main className="container mx-auto grid grid-cols-1 gap-6 px-4 pb-12 pt-6 lg:grid-cols-2">
-        {/* Левая колонка - Карта */}
-        <div className="lg:col-span-1">
-          <Card>
-            <CardHeader>
-              <CardTitle>Карта расходов</CardTitle>
-              <CardDescription>
-                Визуализация городов, в которых вы совершали траты.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="h-[400px] w-full overflow-hidden rounded-lg border">
-                {yandexApiKey ? (
-                  <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
-                    <Map state={mapState} width="100%" height="100%" />
-                  </YMaps>
-                ) : (
-                  <div className="flex h-full items-center justify-center bg-red-50 text-red-700">
-                    Ошибка: API-ключ для Яндекс Карт не настроен.
-                  </div>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-        {/* Правая колонка - Менеджер синонимов */}
-        <div className="lg:col-span-1">
-          <CitySynonymManager />
-        </div>
+      <main className="container mx-auto grid gap-6 px-4 pb-12 pt-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Карта расходов</CardTitle>
+            <CardDescription>
+              Визуализация городов, в которых вы совершали траты.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[400px] w-full overflow-hidden rounded-lg border">
+              {yandexApiKey ? (
+                <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
+                  <Map state={mapState} width="100%" height="100%" />
+                </YMaps>
+              ) : (
+                <div className="flex h-full items-center justify-center bg-red-50 text-red-700">
+                  Ошибка: API-ключ для Яндекс Карт не настроен.
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <CitySynonymManager />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- переместил карточку со справочником городов под карту расходов на странице /cities
- убрал старую статичную SVG-карту и кнопку "Координаты", добавив подтверждение координат при создании города через карту Яндекса
- настроил автопоиск координат по названию города и ручной ввод/корректировку перед сохранением

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19b5d62988320809c106d5874e186