### PR TITLE
feat: improve city management with marker presets and unrecognized list

### DIFF
--- a/src/components/settings/CityMap.tsx
+++ b/src/components/settings/CityMap.tsx
@@ -12,7 +12,13 @@ const HEIGHT = 420
 const RUSSIA_ID = 643
 
 interface CityMapProps {
-  cities: { id: string; name: string; total: number; alternate: number; coordinates: { lat: number; lon: number } | null }[]
+  cities: {
+    id: string;
+    name: string;
+    total: number;
+    alternate: number;
+    coordinates: { lat: number; lon: number; markerPreset?: string | null } | null;
+  }[];
 }
 
 interface Marker {
@@ -24,6 +30,7 @@ interface Marker {
   y: number
   radius: number
   hasCoordinates: boolean
+  color: string
 }
 
 const normaliseName = (value: string) => value.trim().toLowerCase()
@@ -83,6 +90,19 @@ const countries = feature(
 
 const russiaFeature = countries.features.find(item => item.id === RUSSIA_ID) as Feature<Geometry> | undefined
 
+const DEFAULT_MARKER_COLOR = '#2563EB'
+
+const MARKER_COLORS: Record<string, string> = {
+  'islands#blueIcon': '#2563EB',
+  'islands#redIcon': '#DC2626',
+  'islands#greenIcon': '#16A34A',
+  'islands#darkOrangeIcon': '#EA580C',
+  'islands#violetIcon': '#7C3AED',
+  'islands#blackIcon': '#1F2937',
+}
+
+const normalisePreset = (preset?: string | null) => preset ?? 'islands#blueIcon'
+
 const CityMapComponent = ({ cities }: CityMapProps) => {
   const projection = useMemo(() => {
     const proj = geoMercator()
@@ -137,6 +157,9 @@ const CityMapComponent = ({ cities }: CityMapProps) => {
 
       const radius = Math.min(6 + city.alternate * 2, 14)
 
+      const preset = normalisePreset(city.coordinates?.markerPreset)
+      const color = MARKER_COLORS[preset] ?? DEFAULT_MARKER_COLOR
+
       return {
         id: city.id,
         name: city.name,
@@ -145,7 +168,8 @@ const CityMapComponent = ({ cities }: CityMapProps) => {
         x: position[0],
         y: position[1],
         radius,
-        hasCoordinates
+        hasCoordinates,
+        color,
       }
     })
   }, [cities, projection])
@@ -179,13 +203,22 @@ const CityMapComponent = ({ cities }: CityMapProps) => {
               aria-label={label}
             >
               <span
-                className="flex items-center justify-center rounded-full border text-xs font-semibold transition border-slate-400 bg-white text-slate-600 group-hover:border-slate-600 group-hover:text-slate-700"
-                style={{ width: `${marker.radius * 2}px`, height: `${marker.radius * 2}px` }}
+                className="flex items-center justify-center rounded-full border text-xs font-semibold transition bg-white"
+                style={{
+                  width: `${marker.radius * 2}px`,
+                  height: `${marker.radius * 2}px`,
+                  borderColor: marker.color,
+                  color: marker.color,
+                }}
               >
                 {marker.alternate}
               </span>
               <span
-                className="mt-1 block whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] transition border-slate-200 bg-white text-slate-600 group-hover:border-slate-300 group-hover:text-slate-700"
+                className="mt-1 block whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] transition bg-white"
+                style={{
+                  borderColor: marker.color,
+                  color: marker.color,
+                }}
               >
                 {marker.name}
                 {!marker.hasCoordinates && ' *'}

--- a/src/lib/actions/unrecognizedCities.ts
+++ b/src/lib/actions/unrecognizedCities.ts
@@ -1,0 +1,128 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { createServerClient } from '@/lib/supabase/server'
+import { createCitySynonym } from './synonyms'
+
+const unrecognizedCityIdSchema = z.object({
+  id: z.string().uuid('Некорректный идентификатор города'),
+})
+
+const attachUnrecognizedCitySchema = z.object({
+  unrecognizedCityId: z.string().uuid('Некорректный идентификатор города'),
+  cityId: z.string().uuid('Некорректный идентификатор существующего города'),
+})
+
+export async function getUnrecognizedCities() {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const { data, error } = await supabase
+      .from('unrecognized_cities')
+      .select('id, name, frequency, first_seen, last_seen')
+      .eq('user_id', user.id)
+      .order('last_seen', { ascending: false, nullsFirst: false })
+      .order('frequency', { ascending: false, nullsFirst: true })
+
+    if (error) {
+      console.error('Ошибка загрузки непознанных городов:', error)
+      return { error: 'Не удалось загрузить список непознанных городов' }
+    }
+
+    return { success: true, data: data ?? [] }
+  } catch (error) {
+    console.error('Не удалось получить непознанные города:', error)
+    return { error: 'Произошла ошибка при загрузке непознанных городов' }
+  }
+}
+
+export async function resolveUnrecognizedCity(data: { id: string }) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = unrecognizedCityIdSchema.parse(data)
+
+    const { error } = await supabase
+      .from('unrecognized_cities')
+      .delete()
+      .eq('id', validated.id)
+      .eq('user_id', user.id)
+
+    if (error) {
+      console.error('Ошибка удаления непознанного города:', error)
+      return { error: 'Не удалось обновить статус города' }
+    }
+
+    revalidatePath('/cities')
+    revalidatePath('/settings')
+    return { success: true }
+  } catch (error) {
+    console.error('Не удалось удалить непознанный город:', error)
+    return { error: 'Произошла ошибка при обновлении списка городов' }
+  }
+}
+
+export async function attachUnrecognizedCity(data: { unrecognizedCityId: string; cityId: string }) {
+  const supabase = await createServerClient()
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' }
+    }
+
+    const validated = attachUnrecognizedCitySchema.parse(data)
+
+    const { data: unrecognized, error: loadError } = await supabase
+      .from('unrecognized_cities')
+      .select('id, name')
+      .eq('id', validated.unrecognizedCityId)
+      .eq('user_id', user.id)
+      .single()
+
+    if (loadError || !unrecognized) {
+      console.error('Ошибка получения непознанного города:', loadError)
+      return { error: 'Не удалось найти выбранный город' }
+    }
+
+    const synonymResult = await createCitySynonym({
+      cityId: validated.cityId,
+      synonym: unrecognized.name,
+    })
+
+    if (synonymResult.error) {
+      return { error: synonymResult.error }
+    }
+
+    const { error: deleteError } = await supabase
+      .from('unrecognized_cities')
+      .delete()
+      .eq('id', validated.unrecognizedCityId)
+      .eq('user_id', user.id)
+
+    if (deleteError) {
+      console.error('Ошибка удаления непознанного города после привязки:', deleteError)
+      return { error: 'Синоним добавлен, но не удалось обновить список непознанных городов' }
+    }
+
+    revalidatePath('/cities')
+    revalidatePath('/settings')
+
+    return { success: true, data: synonymResult.data }
+  } catch (error) {
+    console.error('Не удалось прикрепить непознанный город:', error)
+    return { error: 'Произошла ошибка при добавлении альтернативного названия' }
+  }
+}

--- a/src/lib/validations/cities.ts
+++ b/src/lib/validations/cities.ts
@@ -5,6 +5,7 @@ export const updateCityCoordinatesSchema = z.object({
   coordinates: z.object({
     lat: z.number(),
     lon: z.number(),
+    markerPreset: z.string().min(1).optional().nullable(),
   }),
 });
 


### PR DESCRIPTION
## Summary
- add server actions for loading, resolving and attaching unrecognized cities to the canonical list
- enhance city management UI with dropdowns for unrecognized cities, marker presets, search placement, and clickable city names that focus the map
- allow choosing marker presets and propagate color styling to the city overview map markers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d87018cc8320a98645924742acda