### PR TITLE
feat: enhance city markers and quick city input

### DIFF
--- a/src/components/cities/CityMarkerIcon.tsx
+++ b/src/components/cities/CityMarkerIcon.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { markerPresetLookup } from '@/lib/constants/cityMarkers'
+import { normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
+import { cn } from '@/lib/utils'
+
+interface CityMarkerIconProps {
+  preset?: string | null
+  active?: boolean
+  className?: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const sizeToClass: Record<NonNullable<CityMarkerIconProps['size']>, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6'
+}
+
+export function CityMarkerIcon({
+  preset,
+  active = true,
+  className,
+  size = 'sm'
+}: CityMarkerIconProps) {
+  const normalisedPreset = normaliseMarkerPreset(preset)
+  const marker = markerPresetLookup.get(normalisedPreset)
+  const color = marker?.color ?? (active ? '#0EA5E9' : '#94A3B8')
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={cn(sizeToClass[size], 'shrink-0 transition', className)}
+      style={{ color }}
+    >
+      <path
+        d="M12 2.25a6.25 6.25 0 0 0-6.25 6.25c0 4.69 5.15 11.06 5.37 11.32a1 1 0 0 0 1.76 0c.22-.26 5.37-6.63 5.37-11.32A6.25 6.25 0 0 0 12 2.25Zm0 8.75a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/src/components/cities/MarkerPresetPicker.tsx
+++ b/src/components/cities/MarkerPresetPicker.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover'
+import { CityMarkerIcon } from '@/components/cities/CityMarkerIcon'
+import { MARKER_PRESETS, markerPresetLookup } from '@/lib/constants/cityMarkers'
+import { normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
+import { cn } from '@/lib/utils'
+
+interface MarkerPresetPickerProps {
+  value?: string | null
+  onChange: (value: string) => void
+  disabled?: boolean
+  triggerClassName?: string
+  align?: 'start' | 'center' | 'end'
+  withLabels?: boolean
+}
+
+export function MarkerPresetPicker({
+  value,
+  onChange,
+  disabled = false,
+  triggerClassName,
+  align = 'start',
+  withLabels = false
+}: MarkerPresetPickerProps) {
+  const [open, setOpen] = useState(false)
+
+  const selectedPreset = normaliseMarkerPreset(value)
+  const marker = markerPresetLookup.get(selectedPreset)
+
+  const handleSelect = (preset: string) => {
+    onChange(preset)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={(nextOpen) => !disabled && setOpen(nextOpen)}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500',
+            disabled && 'cursor-not-allowed opacity-60',
+            triggerClassName
+          )}
+          aria-label={marker ? `Маркер: ${marker.label}` : 'Выбрать маркер'}
+          disabled={disabled}
+        >
+          <CityMarkerIcon preset={selectedPreset} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-2" align={align} sideOffset={6}>
+        <div className="grid grid-cols-2 gap-2">
+          {MARKER_PRESETS.map((preset) => (
+            <button
+              key={preset.value}
+              type="button"
+              onClick={() => handleSelect(preset.value)}
+              className={cn(
+                'flex items-center gap-2 rounded-md border border-transparent px-2 py-2 text-left text-sm text-slate-700 transition hover:border-slate-200 hover:bg-slate-50',
+                preset.value === selectedPreset && 'border-sky-400 bg-sky-50'
+              )}
+            >
+              <CityMarkerIcon preset={preset.value} />
+              {withLabels && <span className="text-xs font-medium text-slate-700">{preset.label}</span>}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/expense-input/ExpenseForm.tsx
+++ b/src/components/expense-input/ExpenseForm.tsx
@@ -160,13 +160,16 @@ export function ExpenseForm({
     startTransition(async () => {
       try {
         // Создаем расход без указания категории - система сама определит
+        const trimmedCityInput = formData.city.trim()
+
         const expenseData: CreateExpenseData = {
           amount: formData.amount,
           description: formData.description,
           notes: formData.notes || undefined,
           expense_date: formData.expense_date,
           expense_time: formData.expense_time || undefined,
-          city_id: formData.city || undefined,
+          city_id: undefined,
+          city_input: trimmedCityInput || undefined,
           input_method: formData.input_method
           // category_id не указываем - система автоматически определит или поместит в неопознанные
         }

--- a/src/components/expenses/ExpensesPageContent.tsx
+++ b/src/components/expenses/ExpensesPageContent.tsx
@@ -12,6 +12,8 @@ import { formatDateLocaleRu } from '@/lib/utils/dateUtils'
 import { useToast } from '@/hooks/useToast'
 import type { Category, ExpenseWithCategory } from '@/types'
 import Link from 'next/link'
+import { CityMarkerIcon } from '@/components/cities/CityMarkerIcon'
+import { normaliseMarkerPreset, parseCityCoordinates } from '@/lib/utils/cityCoordinates'
 
 interface ExpensesPageContentProps {
   initialExpenses: ExpenseWithCategory[]
@@ -133,8 +135,13 @@ export function ExpensesPageContent({
 
       {/* Список расходов */}
       <div className="space-y-2">
-        {filteredExpenses.map((expense) => (
-          <Card key={expense.id} className="p-3">
+        {filteredExpenses.map((expense) => {
+          const cityCoordinates = expense.city ? parseCityCoordinates(expense.city.coordinates ?? null) : null
+          const markerPreset = cityCoordinates ? normaliseMarkerPreset(cityCoordinates.markerPreset) : undefined
+          const cityLabel = expense.city?.name ?? expense.raw_city_input ?? null
+
+          return (
+            <Card key={expense.id} className="p-3">
             <div className="flex items-center gap-3 min-w-0">
               {/* Сумма */}
               <div className="text-lg font-semibold text-gray-900 flex-shrink-0">
@@ -173,8 +180,18 @@ export function ExpensesPageContent({
                 ) : null}
               </div>
 
+              {/* Город */}
+              <div className="flex-shrink-0">
+                {cityLabel && (
+                  <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-600">
+                    <CityMarkerIcon preset={markerPreset} active={Boolean(cityCoordinates)} />
+                    <span className="max-w-[140px] truncate">{cityLabel}</span>
+                  </div>
+                )}
+              </div>
+
               {/* Примечание - редактируемое поле */}
-              <InlineNotesEditor 
+              <InlineNotesEditor
                 expense={expense}
                 onUpdate={handleExpenseUpdate}
               />
@@ -208,8 +225,9 @@ export function ExpensesPageContent({
                 {expense.description}
               </div>
             )}
-          </Card>
-        ))}
+            </Card>
+          )
+        })}
         
         {filteredExpenses.length === 0 && hideUncategorized && (
           <Card className="p-8 text-center">

--- a/src/hooks/useCitySynonyms.ts
+++ b/src/hooks/useCitySynonyms.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { getCitySynonyms } from '@/lib/actions/synonyms'
 import { syncCitySynonyms } from '@/lib/utils/cityParser'
+import { parseCityCoordinates, normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
 import type { CitySynonymWithCity } from '@/types'
 
 interface CitySynonymRecord {
@@ -10,6 +11,8 @@ interface CitySynonymRecord {
   cityId: string
   cityName: string
   synonym: string
+  markerPreset: string | null
+  hasCoordinates: boolean
 }
 
 export function useCitySynonyms() {
@@ -34,11 +37,16 @@ export function useCitySynonyms() {
               if (!cityId) {
                 return null
               }
+
+              const parsedCoordinates = parseCityCoordinates(record.city?.coordinates ?? null)
+
               return {
                 id: Number(record.id),
                 cityId,
                 cityName,
-                synonym: record.synonym
+                synonym: record.synonym,
+                markerPreset: parsedCoordinates ? normaliseMarkerPreset(parsedCoordinates.markerPreset) : null,
+                hasCoordinates: Boolean(parsedCoordinates)
               } satisfies CitySynonymRecord
             })
             .filter((record): record is CitySynonymRecord => record !== null)

--- a/src/lib/constants/cityMarkers.ts
+++ b/src/lib/constants/cityMarkers.ts
@@ -1,0 +1,23 @@
+export type MarkerPresetConfig = {
+  value: string
+  label: string
+  color: string
+}
+
+export const DEFAULT_MARKER_PRESET = 'islands#blueIcon'
+
+export const MARKER_PRESETS: MarkerPresetConfig[] = [
+  { value: 'islands#blueIcon', label: 'Синий маркер', color: '#2563EB' },
+  { value: 'islands#redIcon', label: 'Красный маркер', color: '#DC2626' },
+  { value: 'islands#greenIcon', label: 'Зелёный маркер', color: '#16A34A' },
+  { value: 'islands#darkOrangeIcon', label: 'Оранжевый маркер', color: '#EA580C' },
+  { value: 'islands#violetIcon', label: 'Фиолетовый маркер', color: '#7C3AED' },
+  { value: 'islands#blackIcon', label: 'Графитовый маркер', color: '#1F2937' }
+]
+
+export const markerPresetLookup = new Map(MARKER_PRESETS.map((preset) => [preset.value, preset] as const))
+
+export function getMarkerColor(preset?: string | null, fallback?: string) {
+  const normalised = preset ?? DEFAULT_MARKER_PRESET
+  return markerPresetLookup.get(normalised)?.color ?? fallback ?? '#94A3B8'
+}

--- a/src/lib/utils/cityCoordinates.ts
+++ b/src/lib/utils/cityCoordinates.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_MARKER_PRESET } from '@/lib/constants/cityMarkers'
+
+export type CityCoordinates = {
+  lat: number
+  lon: number
+  markerPreset?: string | null
+}
+
+const normaliseCoordinateInput = (value: string) => value.trim().replace(',', '.')
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+export const normaliseMarkerPreset = (preset?: string | null) => preset ?? DEFAULT_MARKER_PRESET
+
+export const parseCityCoordinates = (value: unknown): CityCoordinates | null => {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const { lat, lon, markerPreset, marker_preset: markerPresetAlt } = value as {
+    lat?: unknown
+    lon?: unknown
+    markerPreset?: unknown
+    marker_preset?: unknown
+  }
+
+  const latNumber = toNumber(lat)
+  const lonNumber = toNumber(lon)
+
+  if (latNumber === null || lonNumber === null) {
+    return null
+  }
+
+  const preset = typeof markerPreset === 'string'
+    ? markerPreset
+    : typeof markerPresetAlt === 'string'
+      ? markerPresetAlt
+      : null
+
+  return {
+    lat: latNumber,
+    lon: lonNumber,
+    markerPreset: preset
+  }
+}
+
+export const parseManualCoordinatePair = (lat: string, lon: string): Pick<CityCoordinates, 'lat' | 'lon'> | null => {
+  const latNumber = toNumber(normaliseCoordinateInput(lat))
+  const lonNumber = toNumber(normaliseCoordinateInput(lon))
+
+  if (latNumber === null || lonNumber === null) {
+    return null
+  }
+
+  return { lat: latNumber, lon: lonNumber }
+}

--- a/src/lib/validations/expenses.ts
+++ b/src/lib/validations/expenses.ts
@@ -32,6 +32,13 @@ export const expenseSchema = z.object({
     }, 'Неверное время')
     .nullable()
     .optional(),
+  city_id: z.string()
+    .uuid('Неверный формат города')
+    .nullable()
+    .optional(),
+  city_input: z.string()
+    .max(100, 'Название города не должно превышать 100 символов')
+    .optional(),
   input_method: z.enum(['single', 'bulk_table'])
     .default('single'),
   batch_id: z.string()
@@ -73,6 +80,13 @@ export const updateExpenseSchema = z.object({
       return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59
     }, 'Неверное время')
     .nullable()
+    .optional(),
+  city_id: z.string()
+    .uuid('Неверный формат города')
+    .nullable()
+    .optional(),
+  city_input: z.string()
+    .max(100, 'Название города не должно превышать 100 символов')
     .optional()
 })
 
@@ -107,6 +121,13 @@ export const bulkExpenseRowSchema = z.object({
       return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59
     }, 'Неверное время')
     .nullable()
+    .optional(),
+  city_id: z.string()
+    .uuid('Неверный формат города')
+    .nullable()
+    .optional(),
+  city_input: z.string()
+    .max(100, 'Название города не должно превышать 100 символов')
     .optional(),
   city: z.string()
     .max(100, 'Название города не должно превышать 100 символов')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -511,6 +511,7 @@ export type CategoryKeywordWithSynonyms = CategoryKeyword & {
 
 export type ExpenseWithCategory = Expense & {
   category: Category | null
+  city?: Pick<City, 'id' | 'name' | 'coordinates'> | null
 }
 
 export type CategoryWithKeywords = Category & {
@@ -533,6 +534,7 @@ export type CreateExpenseData = {
   input_method?: 'single' | 'bulk_table'
   batch_id?: string
   city_id?: string | null // Ссылка на справочник городов
+  city_input?: string | null // Исходный ввод города
 }
 
 export type CreateCategoryData = {


### PR DESCRIPTION
## Summary
- add reusable city marker icon/picker components with preset metadata
- wire quick and full expense forms plus city synonym manager to use marker-aware city selection
- resolve cities in expense actions, surface marker data in listings, and extend schemas/types for new fields

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d1e495eb508320b3fa489f4888a1b4