### PR TITLE
feat(cities): enhance map filters and marker management

### DIFF
--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -1,17 +1,152 @@
-// src/app/(dashboard)/cities/page.tsx
-'use client'; // Временно делаем страницу клиентской для простоты
-import { StickyPageHeader } from '@/components/layout/StickyPageHeader';
-import { CitySynonymManager } from '@/components/settings/CitySynonymManager';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
-import { YMaps, Map } from '@pbe/react-yandex-maps';
-// На этом шаге мы используем 'use client' для простоты.
-// На следующих шагах мы вернемся к серверному компоненту.
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { StickyPageHeader } from '@/components/layout/StickyPageHeader'
+import { CitySynonymManager } from '@/components/settings/CitySynonymManager'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { YMaps, Map as YandexMap, Placemark } from '@pbe/react-yandex-maps'
+import { DEFAULT_MARKER_PRESET } from '@/lib/constants/cityMarkers'
+
+type CityExpensePeriod = '30d' | '90d' | '365d' | 'all'
+
+type CityExpenseSummary = {
+  cityId: string
+  cityName: string
+  totalAmount: number
+  expenseCount: number
+  coordinates: {
+    lat: number
+    lon: number
+    markerPreset?: string | null
+  } | null
+  lastExpenseDate: string | null
+}
+
+type MapState = {
+  center: [number, number]
+  zoom: number
+}
+
+const MAP_DEFAULT_STATE: MapState = {
+  center: [55.751574, 37.573856],
+  zoom: 4
+}
+
+const PERIOD_OPTIONS: Array<{ value: CityExpensePeriod; label: string; description: string }> = [
+  { value: '30d', label: '30 дней', description: 'Последний месяц расходов по городам.' },
+  { value: '90d', label: '90 дней', description: 'Квартальный обзор перемещений.' },
+  { value: '365d', label: '365 дней', description: 'Динамика за последний год.' },
+  { value: 'all', label: 'Всё время', description: 'Вся история трат по городам.' }
+]
+
+const formatDate = (value: string | null | undefined) => {
+  if (!value) {
+    return '—'
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+  return parsed.toLocaleDateString('ru-RU')
+}
+
 export default function CitiesPage() {
-  const yandexApiKey = process.env.NEXT_PUBLIC_YANDEX_MAPS_API_KEY;
-  const mapState = {
-    center: [55.75, 37.62], // Центр Москвы
-    zoom: 4,
-  };
+  const yandexApiKey = process.env.NEXT_PUBLIC_YANDEX_MAPS_API_KEY
+  const [selectedPeriod, setSelectedPeriod] = useState<CityExpensePeriod>('30d')
+  const [cityExpenses, setCityExpenses] = useState<CityExpenseSummary[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [mapState, setMapState] = useState<MapState>(MAP_DEFAULT_STATE)
+  const mapRef = useRef<unknown>(null)
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('ru-RU', {
+        style: 'currency',
+        currency: 'BYN',
+        maximumFractionDigits: 2
+      }),
+    []
+  )
+
+  const sortedExpenses = useMemo(
+    () => [...cityExpenses].sort((a, b) => b.totalAmount - a.totalAmount),
+    [cityExpenses]
+  )
+
+  const topCities = useMemo(() => sortedExpenses.slice(0, 3), [sortedExpenses])
+  const citiesWithCoordinates = useMemo(
+    () => sortedExpenses.filter(city => Boolean(city.coordinates)),
+    [sortedExpenses]
+  )
+  const totalAmount = useMemo(
+    () => sortedExpenses.reduce((acc, city) => acc + (Number.isFinite(city.totalAmount) ? city.totalAmount : 0), 0),
+    [sortedExpenses]
+  )
+
+  useEffect(() => {
+    const loadCityExpenses = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const response = await fetch(`/api/cities/expenses?period=${selectedPeriod}`, { cache: 'no-store' })
+        const payload = await response.json()
+
+        if (!response.ok || payload?.error) {
+          throw new Error(payload?.error ?? 'Не удалось загрузить карту расходов по городам')
+        }
+
+        const data = Array.isArray(payload?.data) ? (payload.data as CityExpenseSummary[]) : []
+        setCityExpenses(data)
+      } catch (loadError) {
+        console.error('Не удалось загрузить данные для карты расходов по городам', loadError)
+        setCityExpenses([])
+        setError(loadError instanceof Error ? loadError.message : 'Произошла ошибка при загрузке данных')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void loadCityExpenses()
+  }, [selectedPeriod])
+
+  useEffect(() => {
+    if (citiesWithCoordinates.length === 0) {
+      setMapState(MAP_DEFAULT_STATE)
+      return
+    }
+
+    const instance = mapRef.current as {
+      setCenter?: (center: [number, number], zoom?: number) => void
+      setBounds?: (bounds: [[number, number], [number, number]], options?: { checkZoomRange?: boolean; zoomMargin?: number }) => void
+    } | null
+
+    if (citiesWithCoordinates.length === 1) {
+      const coords = citiesWithCoordinates[0].coordinates!
+      const center: [number, number] = [coords.lat, coords.lon]
+      setMapState({ center, zoom: 9 })
+      instance?.setCenter?.(center, 9)
+      return
+    }
+
+    const latitudes = citiesWithCoordinates.map(city => city.coordinates!.lat)
+    const longitudes = citiesWithCoordinates.map(city => city.coordinates!.lon)
+    const bounds: [[number, number], [number, number]] = [
+      [Math.min(...latitudes), Math.min(...longitudes)],
+      [Math.max(...latitudes), Math.max(...longitudes)]
+    ]
+
+    instance?.setBounds?.(bounds, { checkZoomRange: true, zoomMargin: 32 })
+    const center: [number, number] = [
+      (bounds[0][0] + bounds[1][0]) / 2,
+      (bounds[0][1] + bounds[1][1]) / 2
+    ]
+    setMapState(prev => ({ ...prev, center }))
+  }, [citiesWithCoordinates])
+
+  const formatAmount = (value: number) => currencyFormatter.format(Number.isFinite(value) ? value : 0)
+
   return (
     <div className="min-h-screen bg-slate-50">
       <StickyPageHeader
@@ -23,20 +158,110 @@ export default function CitiesPage() {
           <CardHeader>
             <CardTitle>Карта расходов</CardTitle>
             <CardDescription>
-              Визуализация городов, в которых вы совершали траты.
+              Выберите период и изучайте, в каких городах сконцентрированы ваши траты.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="h-[400px] w-full overflow-hidden rounded-lg border">
-              {yandexApiKey ? (
-                <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
-                  <Map state={mapState} width="100%" height="100%" />
-                </YMaps>
-              ) : (
-                <div className="flex h-full items-center justify-center bg-red-50 text-red-700">
-                  Ошибка: API-ключ для Яндекс Карт не настроен.
+            <div className="grid gap-6 lg:grid-cols-[minmax(220px,260px)_minmax(0,1fr)]">
+              <div className="space-y-4">
+                <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Период анализа</p>
+                  <div className="space-y-2">
+                    {PERIOD_OPTIONS.map(option => {
+                      const isActive = option.value === selectedPeriod
+                      return (
+                        <div key={option.value} className="space-y-1">
+                          <Button
+                            type="button"
+                            variant={isActive ? 'primary' : 'outline'}
+                            className="w-full justify-between"
+                            onClick={() => setSelectedPeriod(option.value)}
+                          >
+                            <span>{option.label}</span>
+                            {isActive && <span className="text-xs font-semibold uppercase text-indigo-100">Выбрано</span>}
+                          </Button>
+                          <p className="text-xs text-slate-500">{option.description}</p>
+                        </div>
+                      )
+                    })}
+                  </div>
                 </div>
-              )}
+
+                <div className="space-y-2 rounded-lg border border-slate-200 bg-white p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Сумма за период</p>
+                  <p className="text-2xl font-semibold text-slate-900">{formatAmount(totalAmount)}</p>
+                  <p className="text-xs text-slate-500">
+                    Города на карте: {citiesWithCoordinates.length} из {sortedExpenses.length}
+                  </p>
+                  {error && (
+                    <p className="text-xs text-red-600">{error}</p>
+                  )}
+                </div>
+
+                <div className="space-y-2 rounded-lg border border-slate-200 bg-white p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Топ городов</p>
+                  {topCities.length > 0 ? (
+                    <ul className="space-y-1.5">
+                      {topCities.map(city => (
+                        <li key={city.cityId} className="flex items-center justify-between text-sm text-slate-700">
+                          <span className="font-medium text-slate-900">{city.cityName}</span>
+                          <span>{formatAmount(city.totalAmount)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-slate-500">Нет данных для отображения.</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="h-[360px] w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-100">
+                  {!yandexApiKey ? (
+                    <div className="flex h-full items-center justify-center px-4 text-center text-sm text-red-700">
+                      API-ключ для Яндекс Карт не настроен. Карта недоступна.
+                    </div>
+                  ) : isLoading ? (
+                    <div className="flex h-full items-center justify-center text-sm text-slate-500">Загружаем данные…</div>
+                  ) : error ? (
+                    <div className="flex h-full items-center justify-center px-4 text-center text-sm text-red-600">
+                      {error}
+                    </div>
+                  ) : citiesWithCoordinates.length > 0 ? (
+                    <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
+                      <YandexMap
+                        state={mapState}
+                        width="100%"
+                        height="100%"
+                        modules={['geoObject.addon.balloon', 'geoObject.addon.hint']}
+                        instanceRef={(ref) => {
+                          mapRef.current = ref ?? null
+                        }}
+                      >
+                        {citiesWithCoordinates.map(city => (
+                          <Placemark
+                            key={city.cityId}
+                            geometry={[city.coordinates!.lat, city.coordinates!.lon]}
+                            properties={{
+                              balloonContentHeader: city.cityName,
+                              balloonContentBody: `<div><strong>Сумма: ${formatAmount(city.totalAmount)}</strong><br/>Операций: ${city.expenseCount}${city.lastExpenseDate ? `<br/>Последняя трата: ${formatDate(city.lastExpenseDate)}` : ''}</div>`,
+                              hintContent: `${city.cityName} — ${formatAmount(city.totalAmount)}`
+                            }}
+                            options={{ preset: city.coordinates?.markerPreset ?? DEFAULT_MARKER_PRESET }}
+                          />
+                        ))}
+                      </YandexMap>
+                    </YMaps>
+                  ) : (
+                    <div className="flex h-full items-center justify-center px-4 text-center text-sm text-slate-500">
+                      Нет расходов с координатами за выбранный период.
+                    </div>
+                  )}
+                </div>
+                <p className="text-xs text-slate-500">
+                  Наведите курсор на точку, чтобы увидеть сумму и количество операций. Раскройте маркеры для подробностей.
+                </p>
+              </div>
             </div>
           </CardContent>
         </Card>
@@ -44,5 +269,5 @@ export default function CitiesPage() {
         <CitySynonymManager />
       </main>
     </div>
-  );
+  )
 }

--- a/src/app/api/cities/expenses/route.ts
+++ b/src/app/api/cities/expenses/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase/server'
+import { parseCityCoordinates, normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
+import { DEFAULT_MARKER_PRESET } from '@/lib/constants/cityMarkers'
+
+type CityExpensePeriod = '30d' | '90d' | '365d' | 'all'
+
+type CityExpenseSummary = {
+  cityId: string
+  cityName: string
+  totalAmount: number
+  expenseCount: number
+  coordinates: {
+    lat: number
+    lon: number
+    markerPreset?: string | null
+  } | null
+  lastExpenseDate: string | null
+}
+
+const PERIOD_TO_DAYS: Record<Exclude<CityExpensePeriod, 'all'>, number> = {
+  '30d': 30,
+  '90d': 90,
+  '365d': 365
+}
+
+const resolveDateFrom = (period: CityExpensePeriod): string | null => {
+  if (period === 'all') {
+    return null
+  }
+
+  const days = PERIOD_TO_DAYS[period]
+  const now = new Date()
+  const from = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  from.setDate(from.getDate() - days + 1)
+  return from.toISOString().slice(0, 10)
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createServerClient()
+
+  try {
+    const {
+      data: { user },
+      error: userError
+    } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Пользователь не авторизован' }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const periodParam = (searchParams.get('period') ?? '30d') as CityExpensePeriod
+    const period: CityExpensePeriod = ['30d', '90d', '365d', 'all'].includes(periodParam)
+      ? periodParam
+      : '30d'
+
+    const dateFrom = resolveDateFrom(period)
+
+    let query = supabase
+      .from('expenses')
+      .select('amount, expense_date, city_id, city:cities(id, name, coordinates)')
+      .eq('user_id', user.id)
+      .not('city_id', 'is', null)
+
+    if (dateFrom) {
+      query = query.gte('expense_date', dateFrom)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error('Ошибка загрузки расходов по городам:', error)
+      return NextResponse.json({ error: 'Не удалось загрузить данные' }, { status: 500 })
+    }
+
+    const summaryMap = new Map<string, CityExpenseSummary>()
+
+    for (const item of data ?? []) {
+      const cityId = item.city_id as string | null
+      const city = item.city as { id: string; name: string; coordinates: unknown } | null
+
+      if (!cityId || !city?.id) {
+        continue
+      }
+
+      const amount = typeof item.amount === 'number' ? item.amount : Number.parseFloat(String(item.amount ?? 0))
+      const parsedCoordinates = parseCityCoordinates(city.coordinates)
+      const coordinates = parsedCoordinates
+        ? { ...parsedCoordinates, markerPreset: normaliseMarkerPreset(parsedCoordinates.markerPreset) }
+        : null
+
+      const existing = summaryMap.get(cityId)
+
+      if (existing) {
+        existing.totalAmount += Number.isFinite(amount) ? amount : 0
+        existing.expenseCount += 1
+        if (!existing.coordinates && coordinates) {
+          existing.coordinates = coordinates
+        }
+        if (item.expense_date && (!existing.lastExpenseDate || item.expense_date > existing.lastExpenseDate)) {
+          existing.lastExpenseDate = item.expense_date
+        }
+      } else {
+        summaryMap.set(cityId, {
+          cityId,
+          cityName: city.name,
+          totalAmount: Number.isFinite(amount) ? amount : 0,
+          expenseCount: 1,
+          coordinates,
+          lastExpenseDate: item.expense_date ?? null
+        })
+      }
+    }
+
+    const summaries = Array.from(summaryMap.values())
+      .map((entry) => ({
+        ...entry,
+        coordinates: entry.coordinates
+          ? { ...entry.coordinates, markerPreset: entry.coordinates.markerPreset ?? DEFAULT_MARKER_PRESET }
+          : null
+      }))
+      .sort((a, b) => b.totalAmount - a.totalAmount)
+
+    return NextResponse.json({ success: true, data: summaries, period })
+  } catch (err) {
+    console.error('Неизвестная ошибка при формировании карты расходов по городам:', err)
+    return NextResponse.json({ error: 'Произошла ошибка при загрузке данных' }, { status: 500 })
+  }
+}

--- a/src/components/cities/MarkerPresetPicker.tsx
+++ b/src/components/cities/MarkerPresetPicker.tsx
@@ -13,7 +13,6 @@ interface MarkerPresetPickerProps {
   disabled?: boolean
   triggerClassName?: string
   align?: 'start' | 'center' | 'end'
-  withLabels?: boolean
 }
 
 export function MarkerPresetPicker({
@@ -21,8 +20,7 @@ export function MarkerPresetPicker({
   onChange,
   disabled = false,
   triggerClassName,
-  align = 'start',
-  withLabels = false
+  align = 'start'
 }: MarkerPresetPickerProps) {
   const [open, setOpen] = useState(false)
 
@@ -50,20 +48,20 @@ export function MarkerPresetPicker({
           <CityMarkerIcon preset={selectedPreset} />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-56 p-2" align={align} sideOffset={6}>
-        <div className="grid grid-cols-2 gap-2">
+      <PopoverContent className="w-auto rounded-lg border border-slate-200 bg-white p-2" align={align} sideOffset={6}>
+        <div className="grid grid-cols-3 gap-1">
           {MARKER_PRESETS.map((preset) => (
             <button
               key={preset.value}
               type="button"
               onClick={() => handleSelect(preset.value)}
               className={cn(
-                'flex items-center gap-2 rounded-md border border-transparent px-2 py-2 text-left text-sm text-slate-700 transition hover:border-slate-200 hover:bg-slate-50',
+                'flex h-10 w-10 items-center justify-center rounded-md border border-transparent text-slate-700 transition hover:border-slate-200 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400',
                 preset.value === selectedPreset && 'border-sky-400 bg-sky-50'
               )}
+              aria-label={preset.label}
             >
               <CityMarkerIcon preset={preset.value} />
-              {withLabels && <span className="text-xs font-medium text-slate-700">{preset.label}</span>}
             </button>
           ))}
         </div>

--- a/src/components/settings/CitySynonymManager.tsx
+++ b/src/components/settings/CitySynonymManager.tsx
@@ -828,7 +828,7 @@ export function CitySynonymManager() {
                   <div className="space-y-3">
                     <div className="space-y-2">
                       <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        Непознанные города
+                        Неопознанные города
                       </span>
                       <SearchableSelect
                         options={unrecognizedCityOptions}
@@ -837,13 +837,15 @@ export function CitySynonymManager() {
                         placeholder={isLoadingUnrecognized ? 'Загружаем список…' : 'Выберите город из расходов'}
                         className="w-full"
                         disabled={isLoadingUnrecognized || isSubmitting}
+                        maxVisibleOptions={3}
+                        forceOpen
                       />
                       <p className="text-xs text-slate-500">
-                        Список городов, найденных в выписках, но ещё не добавленных в справочник.
+                        Список городов, найденных в выписках, отображается тремя первыми значениями. Раскройте его, чтобы увидеть полный перечень.
                       </p>
                     </div>
                     {selectedUnrecognizedCity && (
-                      <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-4">
+                      <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
                         <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-slate-700">
                           <div className="space-y-1">
                             <p className="font-medium text-slate-900">{selectedUnrecognizedCity.name}</p>
@@ -855,44 +857,44 @@ export function CitySynonymManager() {
                             Сбросить
                           </Button>
                         </div>
-                        <div className="flex flex-wrap gap-2">
-                          <Button type="button" variant="outline" onClick={handleUseUnrecognizedCity} disabled={isSubmitting}>
-                            Использовать как новый город
-                          </Button>
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-6">
                           <Button
                             type="button"
-                            variant="secondary"
-                            onClick={() => setNewCity(selectedUnrecognizedCity.name)}
+                            variant="outline"
+                            onClick={handleUseUnrecognizedCity}
                             disabled={isSubmitting}
+                            className="lg:self-start"
                           >
-                            Подставить в поле ввода
+                            Использовать как новый город
                           </Button>
-                        </div>
-                        <div className="space-y-2">
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                            Прикрепить как альтернативный вариант
-                          </label>
-                          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                            <SearchableSelect
-                              options={citySelectionOptions}
-                              value={selectedAttachCityId}
-                              onChange={value => setSelectedAttachCityId(value)}
-                              placeholder="Выберите основной город"
-                              size="sm"
-                              disabled={isAttachingUnrecognized}
-                            />
-                            <Button
-                              type="button"
-                              onClick={handleAttachUnrecognizedCity}
-                              isLoading={isAttachingUnrecognized}
-                              disabled={isAttachingUnrecognized || !selectedAttachCityId}
-                            >
-                              Прикрепить
-                            </Button>
+                          <div className="flex flex-1 flex-col gap-2">
+                            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                              Прикрепить как альтернативный вариант
+                            </span>
+                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                              <SearchableSelect
+                                options={citySelectionOptions}
+                                value={selectedAttachCityId}
+                                onChange={value => setSelectedAttachCityId(value)}
+                                placeholder="Выберите основной город"
+                                size="sm"
+                                disabled={isAttachingUnrecognized}
+                                className="w-full sm:flex-1"
+                                maxVisibleOptions={3}
+                              />
+                              <Button
+                                type="button"
+                                onClick={handleAttachUnrecognizedCity}
+                                isLoading={isAttachingUnrecognized}
+                                disabled={isAttachingUnrecognized || !selectedAttachCityId}
+                              >
+                                Прикрепить
+                              </Button>
+                            </div>
+                            <p className="text-xs text-slate-500">
+                              Альтернативное название будет добавлено к выбранному городу, а запись исчезнет из списка неопознанных.
+                            </p>
                           </div>
-                          <p className="text-xs text-slate-500">
-                            Альтернативное название будет добавлено к выбранному городу, а запись исчезнет из списка непознанных.
-                          </p>
                         </div>
                       </div>
                     )}
@@ -916,7 +918,6 @@ export function CitySynonymManager() {
                           value={selectedMarkerPreset}
                           onChange={handleNewCityMarkerPresetChange}
                           disabled={isSubmitting}
-                          withLabels
                           align="start"
                           triggerClassName="absolute inset-y-0 left-0 flex h-full w-10 items-center justify-center rounded-l-md border-0 bg-transparent text-slate-500 transition hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-0"
                         />

--- a/src/components/ui/SearchableSelect.tsx
+++ b/src/components/ui/SearchableSelect.tsx
@@ -18,35 +18,56 @@ interface SearchableSelectProps {
   required?: boolean
   disabled?: boolean
   size?: 'sm' | 'md' | 'lg'
+  maxVisibleOptions?: number
+  defaultOpen?: boolean
+  forceOpen?: boolean
+}
+
+const optionHeightMap: Record<NonNullable<SearchableSelectProps['size']>, number> = {
+  sm: 32,
+  md: 40,
+  lg: 48
 }
 
 export function SearchableSelect({
   options,
   value,
   onChange,
-  placeholder = "Выберите опцию",
+  placeholder = 'Выберите опцию',
   className,
   required = false,
   disabled = false,
-  size = 'md'
+  size = 'md',
+  maxVisibleOptions,
+  defaultOpen = false,
+  forceOpen = false
 }: SearchableSelectProps) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(forceOpen || defaultOpen)
   const [searchTerm, setSearchTerm] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [showAll, setShowAll] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  // Фильтруем опции по поисковому запросу
-  const filteredOptions = options.filter(option =>
-    option.label.toLowerCase().includes(searchTerm.toLowerCase())
-  )
+  useEffect(() => {
+    if (forceOpen) {
+      setIsOpen(true)
+    }
+  }, [forceOpen])
 
-  // Получаем выбранную опцию
+  useEffect(() => {
+    setShowAll(false)
+  }, [searchTerm])
+
+  const filteredOptions = options.filter(option => option.label.toLowerCase().includes(searchTerm.toLowerCase()))
+
   const selectedOption = options.find(option => option.value === value)
 
-  // Закрываем при клике вне компонента
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
+      if (forceOpen) {
+        return
+      }
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
         setIsOpen(false)
         setSearchTerm('')
@@ -56,9 +77,8 @@ export function SearchableSelect({
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  }, [forceOpen])
 
-  // Обработка клавиш
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (disabled) return
 
@@ -71,18 +91,16 @@ export function SearchableSelect({
         break
       case 'ArrowDown':
         e.preventDefault()
-        setHighlightedIndex(prev => 
-          prev < filteredOptions.length - 1 ? prev + 1 : 0
-        )
+        setHighlightedIndex(prev => (prev < filteredOptions.length - 1 ? prev + 1 : 0))
         break
       case 'ArrowUp':
         e.preventDefault()
-        setHighlightedIndex(prev => 
-          prev > 0 ? prev - 1 : filteredOptions.length - 1
-        )
+        setHighlightedIndex(prev => (prev > 0 ? prev - 1 : filteredOptions.length - 1))
         break
       case 'Escape':
-        setIsOpen(false)
+        if (!forceOpen) {
+          setIsOpen(false)
+        }
         setSearchTerm('')
         setHighlightedIndex(-1)
         break
@@ -91,61 +109,65 @@ export function SearchableSelect({
 
   const handleSelect = (optionValue: string | null) => {
     onChange(optionValue)
-    setIsOpen(false)
+    if (!forceOpen) {
+      setIsOpen(false)
+    }
     setSearchTerm('')
     setHighlightedIndex(-1)
   }
 
   const handleInputClick = () => {
-    if (!disabled) {
+    if (disabled) return
+    if (!forceOpen) {
       setIsOpen(true)
-      inputRef.current?.focus()
     }
+    inputRef.current?.focus()
   }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value)
     setHighlightedIndex(-1)
-    if (!isOpen) setIsOpen(true)
+    if (!isOpen && !forceOpen) setIsOpen(true)
   }
 
+  const visibleOptions = showAll || !maxVisibleOptions ? filteredOptions : filteredOptions.slice(0, maxVisibleOptions)
+  const canToggle = Boolean(maxVisibleOptions && filteredOptions.length > maxVisibleOptions)
+  const optionHeight = optionHeightMap[size]
+  const maxHeight = showAll || !maxVisibleOptions ? 240 : Math.max(120, maxVisibleOptions * optionHeight)
+  const dropdownStyle = { maxHeight }
+  const shouldRenderDropdown = forceOpen || isOpen
+
   return (
-    <div ref={containerRef} className={cn("relative", className)}>
-      {/* Поле ввода */}
+    <div ref={containerRef} className={cn('relative', className)}>
       <div
-        className={cn(
-          "relative w-full cursor-pointer",
-          disabled && "cursor-not-allowed opacity-50"
-        )}
+        className={cn('relative w-full cursor-pointer', disabled && 'cursor-not-allowed opacity-50')}
         onClick={handleInputClick}
       >
         <input
           ref={inputRef}
           type="text"
-          value={isOpen ? searchTerm : (selectedOption?.label || '')}
+          value={shouldRenderDropdown ? searchTerm : selectedOption?.label || ''}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className={cn(
-            "w-full pr-10 border border-gray-300 rounded-md",
-            "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            "bg-white text-gray-900",
-            size === 'sm' && "px-2 py-1 text-sm",
-            size === 'md' && "px-3 py-2",
-            size === 'lg' && "px-4 py-3 text-lg",
-            disabled && "bg-gray-100 cursor-not-allowed"
+            'w-full rounded-md border border-gray-300 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
+            'bg-white text-gray-900',
+            size === 'sm' && 'px-2 py-1 text-sm',
+            size === 'md' && 'px-3 py-2',
+            size === 'lg' && 'px-4 py-3 text-lg',
+            disabled && 'bg-gray-100 cursor-not-allowed'
           )}
           required={required}
           disabled={disabled}
           autoComplete="off"
         />
-        
-        {/* Иконка стрелки */}
-        <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
           <svg
             className={cn(
-              "w-4 h-4 text-gray-400 transition-transform duration-200",
-              isOpen && "transform rotate-180"
+              'h-4 w-4 text-gray-400 transition-transform duration-200',
+              shouldRenderDropdown && !forceOpen && 'rotate-180'
             )}
             fill="none"
             stroke="currentColor"
@@ -156,34 +178,45 @@ export function SearchableSelect({
         </div>
       </div>
 
-      {/* Выпадающий список */}
-      {isOpen && (
-        <div className="absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
-          {filteredOptions.length === 0 ? (
-            <div className="px-3 py-2 text-gray-500 text-sm">
-              Ничего не найдено
-            </div>
+      {shouldRenderDropdown && (
+        <div
+          className={cn(
+            'mt-1 w-full overflow-auto rounded-md border border-gray-300 bg-white',
+            forceOpen ? 'relative z-0 shadow-sm' : 'absolute z-50 shadow-lg'
+          )}
+          style={dropdownStyle}
+        >
+          {visibleOptions.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-gray-500">Ничего не найдено</div>
           ) : (
-            filteredOptions.map((option, index) => (
-              <div
-                key={option.value}
-                className={cn(
-                  "px-3 py-2 cursor-pointer text-sm flex items-center space-x-2",
-                  "hover:bg-gray-100",
-                  highlightedIndex === index && "bg-gray-100",
-                  value === option.value && "bg-blue-50 text-blue-700"
-                )}
-                onClick={() => handleSelect(option.value)}
-              >
-                {option.color && (
-                  <div
-                    className="w-3 h-3 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: option.color }}
-                  />
-                )}
-                <span className="text-gray-900">{option.label}</span>
-              </div>
-            ))
+            <>
+              {visibleOptions.map((option, index) => (
+                <div
+                  key={option.value ?? `option-${index}`}
+                  className={cn(
+                    'flex cursor-pointer items-center space-x-2 px-3 py-2 text-sm',
+                    'hover:bg-gray-100',
+                    highlightedIndex === index && 'bg-gray-100',
+                    value === option.value && 'bg-blue-50 text-blue-700'
+                  )}
+                  onClick={() => handleSelect(option.value)}
+                >
+                  {option.color && (
+                    <div className="h-3 w-3 flex-shrink-0 rounded-full" style={{ backgroundColor: option.color }} />
+                  )}
+                  <span className="text-gray-900">{option.label}</span>
+                </div>
+              ))}
+              {canToggle && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll(prev => !prev)}
+                  className="block w-full px-3 py-2 text-left text-sm font-medium text-sky-600 transition hover:bg-sky-50"
+                >
+                  {showAll ? 'Показать меньше' : `Показать все (${filteredOptions.length})`}
+                </button>
+              )}
+            </>
           )}
         </div>
       )}

--- a/src/lib/constants/cityMarkers.ts
+++ b/src/lib/constants/cityMarkers.ts
@@ -12,7 +12,10 @@ export const MARKER_PRESETS: MarkerPresetConfig[] = [
   { value: 'islands#greenIcon', label: 'Зелёный маркер', color: '#16A34A' },
   { value: 'islands#darkOrangeIcon', label: 'Оранжевый маркер', color: '#EA580C' },
   { value: 'islands#violetIcon', label: 'Фиолетовый маркер', color: '#7C3AED' },
-  { value: 'islands#blackIcon', label: 'Графитовый маркер', color: '#1F2937' }
+  { value: 'islands#blackIcon', label: 'Графитовый маркер', color: '#1F2937' },
+  { value: 'islands#yellowIcon', label: 'Жёлтый маркер', color: '#CA8A04' },
+  { value: 'islands#darkGreenIcon', label: 'Хвойный маркер', color: '#047857' },
+  { value: 'islands#pinkIcon', label: 'Розовый маркер', color: '#DB2777' }
 ]
 
 export const markerPresetLookup = new Map(MARKER_PRESETS.map((preset) => [preset.value, preset] as const))


### PR DESCRIPTION
## Summary
- expand city marker presets and update the picker to a unified nine-icon grid
- improve unrecognized city workflows with expandable searchable selects and streamlined actions
- add an API endpoint and dashboard filters for city expenses with the redesigned map layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26c3149f48320b43bb5d18527c96d