### PR TITLE
Refactor city manager into modular components

### DIFF
--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { StickyPageHeader } from '@/components/layout/StickyPageHeader'
-import { CitySynonymManager } from '@/components/settings/CitySynonymManager'
+import { CityManager } from '@/components/cities/CityManager'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { YMaps, Map as YandexMap, Placemark } from '@pbe/react-yandex-maps'
@@ -266,7 +266,7 @@ export default function CitiesPage() {
           </CardContent>
         </Card>
 
-        <CitySynonymManager />
+        <CityManager />
       </main>
     </div>
   )

--- a/src/components/cities/CityManagerCreateCitySection.tsx
+++ b/src/components/cities/CityManagerCreateCitySection.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { Button, Input } from '@/components/ui';
+import { MarkerPresetPicker } from '@/components/cities/MarkerPresetPicker';
+import { YMaps, Map as YandexMap, Placemark } from '@pbe/react-yandex-maps';
+import { DEFAULT_MARKER_PRESET } from '@/lib/constants/cityMarkers';
+import type { CityCoordinates } from '@/lib/utils/cityCoordinates';
+import { extractEventCoordinates, extractPlacemarkCoordinates, type MapState } from './cityManagerUtils';
+
+interface CityManagerCreateCitySectionProps {
+  newCity: string;
+  onCityChange: (value: string) => void;
+  isSubmitting: boolean;
+  onFindOnMap: () => void;
+  isSearchingCoordinates: boolean;
+  selectedCoordinates: CityCoordinates | null;
+  selectedMarkerPreset: string;
+  onMarkerPresetChange: (value: string) => void;
+  yandexApiKey?: string;
+  mapState: MapState;
+  onMapInstanceChange: (ref: unknown) => void;
+  onSelectCoordinates: (lat: number, lon: number) => void;
+  manualLat: string;
+  manualLon: string;
+  onManualLatChange: (value: string) => void;
+  onManualLonChange: (value: string) => void;
+  onManualBlur: () => void;
+  onManualApply: () => void;
+}
+
+export function CityManagerCreateCitySection({
+  newCity,
+  onCityChange,
+  isSubmitting,
+  onFindOnMap,
+  isSearchingCoordinates,
+  selectedCoordinates,
+  selectedMarkerPreset,
+  onMarkerPresetChange,
+  yandexApiKey,
+  mapState,
+  onMapInstanceChange,
+  onSelectCoordinates,
+  manualLat,
+  manualLon,
+  onManualLatChange,
+  onManualLonChange,
+  onManualBlur,
+  onManualApply,
+}: CityManagerCreateCitySectionProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:gap-2">
+        <div className="flex-grow space-y-2">
+          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="synonym-city">
+            Новый город
+          </label>
+          <div className="relative">
+            <Input
+              id="synonym-city"
+              placeholder="Например: Санкт-Петербург"
+              value={newCity}
+              onChange={(event) => onCityChange(event.target.value)}
+              disabled={isSubmitting}
+              className="h-11 pl-12"
+            />
+            <MarkerPresetPicker
+              value={selectedMarkerPreset}
+              onChange={onMarkerPresetChange}
+              disabled={isSubmitting}
+              align="start"
+              triggerClassName="absolute inset-y-0 left-0 flex h-full w-10 items-center justify-center rounded-l-md border-r border-slate-300 bg-slate-100 text-slate-600 transition hover:bg-slate-200 hover:text-slate-900 focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-0"
+            />
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onFindOnMap}
+            isLoading={isSearchingCoordinates}
+            disabled={!newCity.trim() || isSubmitting}
+            className="h-11"
+          >
+            Найти на карте
+          </Button>
+          <Button type="submit" isLoading={isSubmitting} disabled={isSubmitting || !selectedCoordinates} className="h-11">
+            Добавить город
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 text-xs text-slate-500 sm:flex-row sm:justify-end">
+        <p className="sm:text-right">Укажите название и подтвердите координаты перед сохранением.</p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)]">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Подтверждение координат</p>
+          <div className="h-72 w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-100">
+            {yandexApiKey ? (
+              <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
+                <YandexMap
+                  state={mapState}
+                  width="100%"
+                  height="100%"
+                  modules={['geoObject.addon.balloon', 'geoObject.addon.hint']}
+                  instanceRef={onMapInstanceChange}
+                  onClick={(event: unknown) => {
+                    const coords = extractEventCoordinates(event);
+                    if (!coords) {
+                      return;
+                    }
+                    const [lat, lon] = coords;
+                    onSelectCoordinates(lat, lon);
+                  }}
+                >
+                  {selectedCoordinates && (
+                    <Placemark
+                      geometry={[selectedCoordinates.lat, selectedCoordinates.lon]}
+                      options={{ draggable: true, preset: selectedCoordinates.markerPreset ?? DEFAULT_MARKER_PRESET }}
+                      onDragEnd={(event: { get: (key: string) => unknown }) => {
+                        const coords = extractPlacemarkCoordinates(event.get('target'));
+                        if (!coords) {
+                          return;
+                        }
+                        const [lat, lon] = coords;
+                        onSelectCoordinates(lat, lon);
+                      }}
+                    />
+                  )}
+                </YandexMap>
+              </YMaps>
+            ) : (
+              <div className="flex h-full items-center justify-center px-4 text-center text-sm text-red-700">
+                API-ключ для Яндекс Карт не настроен. Укажите координаты вручную.
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-slate-500">Нажмите на карту или перетащите маркер, чтобы уточнить координаты.</p>
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-4">
+          <p className="text-sm font-medium text-slate-900">Ручной ввод координат</p>
+          <div className="grid gap-3">
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="manual-lat">
+                Широта (lat)
+              </label>
+              <Input
+                id="manual-lat"
+                value={manualLat}
+                onChange={(event) => onManualLatChange(event.target.value)}
+                onBlur={onManualBlur}
+                inputMode="decimal"
+                placeholder="Например: 59.9386"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="manual-lon">
+                Долгота (lon)
+              </label>
+              <Input
+                id="manual-lon"
+                value={manualLon}
+                onChange={(event) => onManualLonChange(event.target.value)}
+                onBlur={onManualBlur}
+                inputMode="decimal"
+                placeholder="Например: 30.3141"
+              />
+            </div>
+          </div>
+          <Button type="button" variant="secondary" onClick={onManualApply} disabled={isSubmitting}>
+            Применить координаты
+          </Button>
+          <p className="text-xs text-slate-500">
+            Введите координаты вручную, если карта недоступна или требуется точное значение.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cities/CityManagerOverviewMapSection.tsx
+++ b/src/components/cities/CityManagerOverviewMapSection.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { YMaps, Map as YandexMap, Placemark } from '@pbe/react-yandex-maps';
+import { DEFAULT_MARKER_PRESET } from '@/lib/constants/cityMarkers';
+import type { CityCoordinates } from '@/lib/utils/cityCoordinates';
+import type { CityGroupWithCoordinates } from './cityManagerTypes';
+import type { MapState } from './cityManagerUtils';
+
+interface CityManagerOverviewMapSectionProps {
+  yandexApiKey?: string;
+  citiesWithCoordinates: CityGroupWithCoordinates[];
+  overviewMapState: MapState;
+  onMapInstanceChange: (ref: unknown) => void;
+  formatCityCoordinates: (coords: CityCoordinates | null) => string;
+}
+
+export function CityManagerOverviewMapSection({
+  yandexApiKey,
+  citiesWithCoordinates,
+  overviewMapState,
+  onMapInstanceChange,
+  formatCityCoordinates,
+}: CityManagerOverviewMapSectionProps) {
+  return (
+    <div className="space-y-2 rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Карта всех городов</p>
+      <div className="h-[420px] w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-100">
+        {yandexApiKey ? (
+          citiesWithCoordinates.length > 0 ? (
+            <YMaps query={{ apikey: yandexApiKey, lang: 'ru_RU' }}>
+              <YandexMap
+                state={overviewMapState}
+                width="100%"
+                height="100%"
+                modules={['geoObject.addon.balloon', 'geoObject.addon.hint']}
+                instanceRef={onMapInstanceChange}
+              >
+                {citiesWithCoordinates.map(city => (
+                  <Placemark
+                    key={city.cityId}
+                    geometry={[city.coordinates.lat, city.coordinates.lon]}
+                    properties={{
+                      balloonContent: `<strong>${city.cityName}</strong><br/>${formatCityCoordinates(city.coordinates)}`,
+                      hintContent: `${city.cityName} (${formatCityCoordinates(city.coordinates)})`
+                    }}
+                    options={{ preset: city.coordinates.markerPreset ?? DEFAULT_MARKER_PRESET }}
+                  />
+                ))}
+              </YandexMap>
+            </YMaps>
+          ) : (
+            <div className="flex h-full items-center justify-center px-4 text-center text-sm text-slate-500">
+              Для отображения на карте добавьте координаты городов.
+            </div>
+          )
+        ) : (
+          <div className="flex h-full items-center justify-center px-4 text-center text-sm text-red-700">
+            API-ключ для Яндекс Карт не настроен. Карта городов недоступна.
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-slate-500">На карте отображаются все города с заданными координатами.</p>
+    </div>
+  );
+}

--- a/src/components/cities/CityManagerStatsCard.tsx
+++ b/src/components/cities/CityManagerStatsCard.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+
+interface CityManagerStatsCardProps {
+  totalCities: number;
+  totalSynonyms: number;
+  customSynonyms: number;
+  coverage: number;
+}
+
+export function CityManagerStatsCard({ totalCities, totalSynonyms, customSynonyms, coverage }: CityManagerStatsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Статистика справочника</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        <div className="flex items-baseline justify-between rounded-lg border border-slate-200 px-3 py-2">
+          <span className="text-sm text-slate-500">Городов</span>
+          <span className="text-lg font-semibold text-slate-900">{totalCities}</span>
+        </div>
+        <div className="flex items-baseline justify-between rounded-lg border border-slate-200 px-3 py-2">
+          <span className="text-sm text-slate-500">Всего записей</span>
+          <span className="text-lg font-semibold text-slate-900">{totalSynonyms}</span>
+        </div>
+        <div className="flex items-baseline justify-between rounded-lg border border-slate-200 px-3 py-2">
+          <span className="text-sm text-slate-500">Альтернативных вариантов</span>
+          <span className="text-lg font-semibold text-slate-900">{customSynonyms}</span>
+        </div>
+        <div className="flex items-baseline justify-between rounded-lg border border-slate-200 px-3 py-2">
+          <span className="text-sm text-slate-500">Покрытие</span>
+          <span className="text-lg font-semibold text-slate-900">{coverage}%</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/cities/CityManagerSynonymListSection.tsx
+++ b/src/components/cities/CityManagerSynonymListSection.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { Button, Input } from '@/components/ui';
+import { MarkerPresetPicker } from '@/components/cities/MarkerPresetPicker';
+import { CityMarkerIcon } from '@/components/cities/CityMarkerIcon';
+import { DEFAULT_MARKER_PRESET, markerPresetLookup } from '@/lib/constants/cityMarkers';
+import { normaliseMarkerPreset } from '@/lib/utils/cityCoordinates';
+import type { CityCoordinates } from '@/lib/utils/cityCoordinates';
+import { AddSynonymForm } from '@/components/settings/AddSynonymForm';
+import type { CityGroup, CitySynonymRecord } from './cityManagerTypes';
+
+interface CityManagerSynonymListSectionProps {
+  searchTerm: string;
+  onSearchTermChange: (value: string) => void;
+  onSearchKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  isLoading: boolean;
+  filteredGroupedSynonyms: CityGroup[];
+  deletingMap: Record<string, boolean>;
+  isSubmitting: boolean;
+  onDeleteSynonym: (synonym: CitySynonymRecord) => void;
+  onCityNameClick: (group: CityGroup) => void;
+  onEditCity: (event: React.MouseEvent, city: { id: string; name: string }) => void;
+  onDeleteCity: (event: React.MouseEvent, city: { id: string; name: string }) => void;
+  onMarkerPresetChange: (cityId: string, value: string) => void;
+  markerUpdatingMap: Record<string, boolean>;
+  formatCityCoordinates: (coords: CityCoordinates | null) => string;
+  onSynonymAdded: () => Promise<void> | void;
+}
+
+export function CityManagerSynonymListSection({
+  searchTerm,
+  onSearchTermChange,
+  onSearchKeyDown,
+  isLoading,
+  filteredGroupedSynonyms,
+  deletingMap,
+  isSubmitting,
+  onDeleteSynonym,
+  onCityNameClick,
+  onEditCity,
+  onDeleteCity,
+  onMarkerPresetChange,
+  markerUpdatingMap,
+  formatCityCoordinates,
+  onSynonymAdded,
+}: CityManagerSynonymListSectionProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500" htmlFor="city-search">
+          Поиск по списку городов
+        </label>
+        <div className="relative">
+          <Input
+            id="city-search"
+            placeholder="Поиск по городу или синониму"
+            value={searchTerm}
+            onChange={(event) => onSearchTermChange(event.target.value)}
+            onKeyDown={onSearchKeyDown}
+            className="pl-9"
+            type="search"
+          />
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">🔍</span>
+        </div>
+        <p className="text-xs text-slate-500">Найдите город в существующем списке для редактирования или удаления.</p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          Загружаем текущий список городов…
+        </div>
+      ) : filteredGroupedSynonyms.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          Ничего не найдено. Проверьте запрос или добавьте новый город.
+        </div>
+      ) : (
+        filteredGroupedSynonyms.map(group => {
+          const canonicalName = group.cityName;
+          const synonymsForCity = group.entries.filter(
+            entry => entry.synonym.trim().toLowerCase() !== canonicalName.trim().toLowerCase()
+          );
+          const hasCoordinates = Boolean(group.coordinates);
+          const coordinatesHint = hasCoordinates ? 'Город отображается на карте' : 'Координаты не определены';
+          const markerLabel = markerPresetLookup.get(normaliseMarkerPreset(group.coordinates?.markerPreset))?.label;
+          const isMarkerUpdating = Boolean(markerUpdatingMap[group.cityId]);
+
+          return (
+            <div key={group.cityId} className="rounded-lg border border-slate-200 bg-white">
+              <div className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      {hasCoordinates ? (
+                        <MarkerPresetPicker
+                          value={group.coordinates?.markerPreset ?? DEFAULT_MARKER_PRESET}
+                          onChange={(value) => onMarkerPresetChange(group.cityId, value)}
+                          disabled={isMarkerUpdating || isSubmitting}
+                          triggerClassName="inline-flex h-8 w-8 items-center justify-center rounded-full border border-transparent bg-slate-100 text-slate-600 transition hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-0"
+                        />
+                      ) : (
+                        <span className="flex items-center justify-center rounded-full bg-slate-100 p-1" title={coordinatesHint}>
+                          <CityMarkerIcon active={false} preset={group.coordinates?.markerPreset} />
+                          <span className="sr-only">{coordinatesHint}</span>
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => onCityNameClick(group)}
+                        className="rounded px-1 text-left text-sm font-medium text-slate-900 transition hover:text-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                      >
+                        {canonicalName}
+                        <span className="ml-2 text-xs font-normal text-slate-500">
+                          ({formatCityCoordinates(group.coordinates ?? null)})
+                        </span>
+                      </button>
+                    </div>
+                    <p className="text-xs text-slate-500">
+                      {synonymsForCity.length > 0
+                        ? `Альтернативных написаний: ${synonymsForCity.length}`
+                        : 'Только основной вариант'}
+                    </p>
+                    {markerLabel && (
+                      <p className="text-xs text-slate-400">Маркер: {markerLabel}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={(event) => group.cityId && onEditCity(event, { id: group.cityId, name: canonicalName })}
+                    disabled={!group.cityId}
+                  >
+                    Редактировать
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={(event) => group.cityId && onDeleteCity(event, { id: group.cityId, name: canonicalName })}
+                    disabled={!group.cityId}
+                  >
+                    Удалить
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-3 border-t border-slate-200 px-4 py-4">
+                {synonymsForCity.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {synonymsForCity.map(entry => (
+                      <span
+                        key={entry.id}
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600"
+                      >
+                        {entry.synonym}
+                        <button
+                          type="button"
+                          onClick={() => onDeleteSynonym(entry)}
+                          className="rounded-full border border-transparent px-1.5 text-slate-400 transition hover:border-red-400 hover:text-red-500"
+                          disabled={!!deletingMap[entry.id.toString()] || isSubmitting}
+                          aria-label="Удалить синоним"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-slate-500">Добавьте варианты написания, которые встречаются в отчетах.</p>
+                )}
+
+                <AddSynonymForm cityId={group.cityId} cityName={canonicalName} onSynonymAdded={onSynonymAdded} />
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/cities/CityManagerUnrecognizedPanel.tsx
+++ b/src/components/cities/CityManagerUnrecognizedPanel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Button } from '@/components/ui';
+import { SearchableSelect } from '@/components/ui/SearchableSelect';
+import type { UnrecognizedCity } from '@/types';
+import { formatDate } from './cityManagerUtils';
+
+export type SelectOption = { value: string | null; label: string };
+
+interface CityManagerUnrecognizedPanelProps {
+  unrecognizedCityOptions: SelectOption[];
+  selectedUnrecognizedCityId: string | null;
+  onSelectUnrecognizedCity: (value: string | null) => void;
+  isLoadingUnrecognized: boolean;
+  isSubmitting: boolean;
+  selectedUnrecognizedCity: UnrecognizedCity | null;
+  onClearUnrecognizedSelection: () => void;
+  onUseUnrecognizedCity: () => void;
+  citySelectionOptions: SelectOption[];
+  selectedAttachCityId: string | null;
+  onSelectAttachCity: (value: string | null) => void;
+  onAttachUnrecognizedCity: () => void;
+  isAttachingUnrecognized: boolean;
+}
+
+export function CityManagerUnrecognizedPanel({
+  unrecognizedCityOptions,
+  selectedUnrecognizedCityId,
+  onSelectUnrecognizedCity,
+  isLoadingUnrecognized,
+  isSubmitting,
+  selectedUnrecognizedCity,
+  onClearUnrecognizedSelection,
+  onUseUnrecognizedCity,
+  citySelectionOptions,
+  selectedAttachCityId,
+  onSelectAttachCity,
+  onAttachUnrecognizedCity,
+  isAttachingUnrecognized,
+}: CityManagerUnrecognizedPanelProps) {
+  return (
+    <div className="space-y-3">
+      <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Неопознанные города
+      </span>
+      <SearchableSelect
+        options={unrecognizedCityOptions}
+        value={selectedUnrecognizedCityId}
+        onChange={onSelectUnrecognizedCity}
+        placeholder={isLoadingUnrecognized ? 'Загружаем список…' : 'Выберите город из расходов'}
+        className="w-full"
+        disabled={isLoadingUnrecognized || isSubmitting}
+        maxVisibleOptions={3}
+        forceOpen
+      />
+      <p className="text-xs text-slate-500">
+        Список городов, найденных в выписках, отображается тремя первыми значениями. Раскройте его, чтобы увидеть полный перечень.
+      </p>
+      {selectedUnrecognizedCity && (
+        <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 text-sm">
+            <div className="text-xs text-slate-500">
+              <p>Всего упоминаний: {selectedUnrecognizedCity.frequency ?? '—'}</p>
+              <p>Последний раз: {formatDate(selectedUnrecognizedCity.last_seen)}</p>
+            </div>
+            <p className="text-center font-medium text-slate-900">{selectedUnrecognizedCity.name}</p>
+            <div className="text-right">
+              <Button type="button" variant="ghost" size="sm" onClick={onClearUnrecognizedSelection}>
+                Сбросить
+              </Button>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-4">
+            <div className="flex flex-col items-center justify-center rounded-lg border bg-slate-50/50 p-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onUseUnrecognizedCity}
+                disabled={isSubmitting}
+                className="w-full"
+              >
+                Использовать как новый город
+              </Button>
+            </div>
+            <div className="space-y-3 rounded-lg border bg-slate-50/50 p-4">
+              <p className="text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Прикрепить как альтернативный вариант
+              </p>
+              <div className="flex flex-col items-stretch gap-2">
+                <SearchableSelect
+                  options={citySelectionOptions}
+                  value={selectedAttachCityId}
+                  onChange={onSelectAttachCity}
+                  placeholder="Выберите основной город"
+                  size="sm"
+                  disabled={isAttachingUnrecognized}
+                  maxVisibleOptions={3}
+                />
+                <Button
+                  type="button"
+                  onClick={onAttachUnrecognizedCity}
+                  isLoading={isAttachingUnrecognized}
+                  disabled={isAttachingUnrecognized || !selectedAttachCityId}
+                >
+                  Прикрепить
+                </Button>
+              </div>
+              <p className="text-center text-xs text-slate-500">
+                Альтернативное название будет добавлено к выбранному городу.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/cities/cityManagerTypes.ts
+++ b/src/components/cities/cityManagerTypes.ts
@@ -1,0 +1,18 @@
+import type { CityCoordinates } from '@/lib/utils/cityCoordinates';
+
+export interface CitySynonymRecord {
+  id: number;
+  cityId: string;
+  cityName: string;
+  synonym: string;
+  coordinates: CityCoordinates | null;
+}
+
+export type CityGroup = {
+  cityId: string;
+  cityName: string;
+  entries: CitySynonymRecord[];
+  coordinates: CityCoordinates | null;
+};
+
+export type CityGroupWithCoordinates = CityGroup & { coordinates: CityCoordinates };

--- a/src/components/cities/cityManagerUtils.ts
+++ b/src/components/cities/cityManagerUtils.ts
@@ -1,0 +1,71 @@
+import { normaliseMarkerPreset, type CityCoordinates } from '@/lib/utils/cityCoordinates';
+
+export type MapState = {
+  center: [number, number];
+  zoom: number;
+};
+
+export const DEFAULT_CENTER: [number, number] = [55.751574, 37.573856];
+export const DEFAULT_ZOOM = 4;
+
+export const createDefaultMapState = (): MapState => ({
+  center: [...DEFAULT_CENTER] as [number, number],
+  zoom: DEFAULT_ZOOM,
+});
+
+export const normaliseCoordinateInput = (value: string) => value.trim().replace(',', '.');
+
+export const coordinatesAreEqual = (a: CityCoordinates | null, b: CityCoordinates | null) => {
+  if (!a && !b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  const sameLat = Math.abs(a.lat - b.lat) < 1e-6;
+  const sameLon = Math.abs(a.lon - b.lon) < 1e-6;
+  const samePreset = normaliseMarkerPreset(a.markerPreset) === normaliseMarkerPreset(b.markerPreset);
+  return sameLat && sameLon && samePreset;
+};
+
+export const extractEventCoordinates = (event: unknown): [number, number] | null => {
+  if (!event || typeof (event as { get?: unknown }).get !== 'function') {
+    return null;
+  }
+  const coords = (event as { get: (key: string) => unknown }).get('coords');
+  if (!Array.isArray(coords) || coords.length < 2) {
+    return null;
+  }
+  const [lat, lon] = coords as [number, number];
+  if (typeof lat !== 'number' || typeof lon !== 'number') {
+    return null;
+  }
+  return [lat, lon];
+};
+
+export const extractPlacemarkCoordinates = (target: unknown): [number, number] | null => {
+  const geometry = (target as { geometry?: { getCoordinates?: () => unknown } })?.geometry;
+  if (!geometry || typeof geometry.getCoordinates !== 'function') {
+    return null;
+  }
+  const coords = geometry.getCoordinates();
+  if (!Array.isArray(coords) || coords.length < 2) {
+    return null;
+  }
+  const [lat, lon] = coords as [number, number];
+  if (typeof lat !== 'number' || typeof lon !== 'number') {
+    return null;
+  }
+  return [lat, lon];
+};
+
+export const formatDate = (value: string | null | undefined) => {
+  if (!value) {
+    return 'неизвестно';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString('ru-RU');
+};


### PR DESCRIPTION
## Summary
- move the city manager feature into the cities module and rename the orchestrator component
- split the monolithic UI into dedicated panels for unrecognized cities, creation form, listing, overview map, and stats
- add shared types/utilities and update the dashboard page to consume the new component structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d28fc20414832091a3a98bd1884132