### PR TITLE
feat: add city favorites and bulk city autocomplete

### DIFF
--- a/src/components/expense-input/bulk-input/BulkExpenseTable.tsx
+++ b/src/components/expense-input/bulk-input/BulkExpenseTable.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react'
+import {
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  useEffect,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ClipboardEvent as ReactClipboardEvent
+} from 'react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { DatePicker } from '@/components/ui/DatePicker'
@@ -9,6 +17,12 @@ import { ErrorMessage } from '@/components/ui/ErrorMessage'
 import { TimeInput, TimeInputRef } from '@/components/ui/TimeInput'
 import type { Category } from '@/types'
 import type { BulkExpenseRowData } from '@/lib/validations/expenses'
+import { useCitySynonyms } from '@/hooks/useCitySynonyms'
+import { CityMarkerIcon } from '@/components/cities/CityMarkerIcon'
+import { normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
+import { cn } from '@/lib/utils'
+import { toggleCityFavorite } from '@/lib/actions/cities'
+import { useToast } from '@/hooks/useToast'
 
 interface BulkExpenseTableProps {
   expenses: BulkExpenseRowData[]
@@ -16,7 +30,16 @@ interface BulkExpenseTableProps {
   validationErrors: Record<string, string>
   onUpdateRow: (tempId: string, field: keyof BulkExpenseRowData, value: any) => void
   onRemoveRow: (tempId: string) => void
-  onPaste: (event: React.ClipboardEvent) => void
+  onPaste: (event: ReactClipboardEvent) => void
+}
+
+type CityOption = {
+  cityId: string
+  cityName: string
+  markerPreset: string | null
+  hasCoordinates: boolean
+  synonyms: string[]
+  isFavorite: boolean
 }
 
 export function BulkExpenseTable({
@@ -28,6 +51,8 @@ export function BulkExpenseTable({
   onPaste
 }: BulkExpenseTableProps) {
   const [editingCell, setEditingCell] = useState<string | null>(null)
+  const { synonyms: citySynonyms, updateCityFavorite } = useCitySynonyms()
+  const { showToast } = useToast()
 
   // Опции для селекта категорий
   const categoryOptions = [
@@ -40,6 +65,97 @@ export function BulkExpenseTable({
   ]
   const timeInputRefs = useRef<Record<string, TimeInputRef | null>>({})
 
+  const [openCityDropdownId, setOpenCityDropdownId] = useState<string | null>(null)
+  const [highlightedCityIndex, setHighlightedCityIndex] = useState(0)
+  const [favoriteMutationCityId, setFavoriteMutationCityId] = useState<string | null>(null)
+  const cityDropdownTimeoutRef = useRef<number | null>(null)
+
+  const { cityOptions, cityLookupBySynonym, cityLookupById } = useMemo(() => {
+    const byId = new Map<string, CityOption>()
+    const bySynonym = new Map<string, CityOption>()
+    const synonymsRegistry = new Map<string, Set<string>>()
+
+    citySynonyms.forEach((record) => {
+      const existing = byId.get(record.cityId)
+
+      const synonymsSet = (() => {
+        let set = synonymsRegistry.get(record.cityId)
+        if (!set) {
+          set = new Set<string>()
+          synonymsRegistry.set(record.cityId, set)
+        }
+        return set
+      })()
+
+      const baseOption: CityOption = existing ?? {
+        cityId: record.cityId,
+        cityName: record.cityName,
+        markerPreset: record.markerPreset,
+        hasCoordinates: record.hasCoordinates,
+        synonyms: [record.cityName],
+        isFavorite: record.isFavorite
+      }
+
+      if (!existing) {
+        byId.set(record.cityId, baseOption)
+        synonymsSet.add(record.cityName.trim().toLowerCase())
+      }
+
+      if (record.markerPreset && !baseOption.markerPreset) {
+        baseOption.markerPreset = record.markerPreset
+      }
+
+      if (record.hasCoordinates) {
+        baseOption.hasCoordinates = true
+      }
+
+      if (record.isFavorite && !baseOption.isFavorite) {
+        baseOption.isFavorite = true
+      }
+
+      const synonymNormalized = record.synonym.trim().toLowerCase()
+      if (!synonymsSet.has(synonymNormalized)) {
+        baseOption.synonyms.push(record.synonym)
+        synonymsSet.add(synonymNormalized)
+      }
+
+      bySynonym.set(synonymNormalized, baseOption)
+      bySynonym.set(record.cityName.trim().toLowerCase(), baseOption)
+    })
+
+    const options = Array.from(byId.values()).sort((a, b) => {
+      if (a.isFavorite !== b.isFavorite) {
+        return a.isFavorite ? -1 : 1
+      }
+      return a.cityName.localeCompare(b.cityName, 'ru')
+    })
+
+    return {
+      cityOptions: options,
+      cityLookupBySynonym: bySynonym,
+      cityLookupById: new Map(options.map(option => [option.cityId, option] as const))
+    }
+  }, [citySynonyms])
+
+  const resolveCityByInput = useCallback((value: string): CityOption | null => {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) {
+      return null
+    }
+    return cityLookupBySynonym.get(normalized) ?? null
+  }, [cityLookupBySynonym])
+
+  const clearCityDropdownTimeout = useCallback(() => {
+    if (cityDropdownTimeoutRef.current) {
+      window.clearTimeout(cityDropdownTimeoutRef.current)
+      cityDropdownTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => {
+    clearCityDropdownTimeout()
+  }, [clearCityDropdownTimeout])
+
 
 
   // Обработка изменения значения в ячейке
@@ -51,9 +167,78 @@ export function BulkExpenseTable({
     onUpdateRow(tempId, field, value)
   }, [onUpdateRow])
 
+  const handleCityInputChange = useCallback((tempId: string, value: string) => {
+    clearCityDropdownTimeout()
+    const match = resolveCityByInput(value)
+    onUpdateRow(tempId, 'city', value)
+    onUpdateRow(tempId, 'city_input', value)
+    onUpdateRow(tempId, 'city_id', match?.cityId ?? null)
+    if (value.trim()) {
+      setOpenCityDropdownId(tempId)
+    } else {
+      setOpenCityDropdownId(null)
+    }
+    setHighlightedCityIndex(0)
+  }, [clearCityDropdownTimeout, onUpdateRow, resolveCityByInput])
+
+  const handleCitySelect = useCallback((tempId: string, option: CityOption) => {
+    clearCityDropdownTimeout()
+    onUpdateRow(tempId, 'city', option.cityName)
+    onUpdateRow(tempId, 'city_input', option.cityName)
+    onUpdateRow(tempId, 'city_id', option.cityId)
+    setOpenCityDropdownId(null)
+    setHighlightedCityIndex(0)
+  }, [clearCityDropdownTimeout, onUpdateRow])
+
+  const handleCityInputFocus = useCallback((tempId: string, hasOptions: boolean) => {
+    clearCityDropdownTimeout()
+    setEditingCell(`${tempId}-city`)
+    if (hasOptions) {
+      setOpenCityDropdownId(tempId)
+      setHighlightedCityIndex(0)
+    }
+  }, [clearCityDropdownTimeout])
+
+  const handleCityInputBlur = useCallback((tempId: string) => {
+    clearCityDropdownTimeout()
+    cityDropdownTimeoutRef.current = window.setTimeout(() => {
+      setOpenCityDropdownId(current => (current === tempId ? null : current))
+    }, 120)
+  }, [clearCityDropdownTimeout])
+
+  const handleCityFavoriteToggle = useCallback(async (option: CityOption | null) => {
+    if (!option) {
+      return
+    }
+
+    const nextValue = !option.isFavorite
+    setFavoriteMutationCityId(option.cityId)
+
+    try {
+      const result = await toggleCityFavorite({ id: option.cityId, isFavorite: nextValue })
+      if (result && 'error' in result && result.error) {
+        showToast(result.error, 'error')
+        return
+      }
+
+      updateCityFavorite(option.cityId, nextValue)
+      showToast(
+        nextValue
+          ? `Город «${option.cityName}» добавлен в избранное`
+          : `Город «${option.cityName}» убран из избранного`,
+        'success'
+      )
+    } catch (error) {
+      console.error('Failed to toggle favorite city in bulk input', error)
+      showToast('Не удалось обновить избранный город', 'error')
+    } finally {
+      setFavoriteMutationCityId(null)
+    }
+  }, [showToast, updateCityFavorite])
+
   // Обработка нажатия Enter для перехода к следующей ячейке
   const handleKeyDown = useCallback((
-    event: React.KeyboardEvent,
+    event: ReactKeyboardEvent,
     tempId: string,
     field: keyof BulkExpenseRowData
   ) => {
@@ -74,6 +259,65 @@ export function BulkExpenseTable({
       }
     }
   }, [expenses])
+
+  const handleCityKeyDown = useCallback((
+    event: ReactKeyboardEvent<HTMLInputElement>,
+    tempId: string,
+    filteredOptions: CityOption[]
+  ) => {
+    const isOpen = openCityDropdownId === tempId
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      clearCityDropdownTimeout()
+      if (!isOpen) {
+        if (filteredOptions.length > 0) {
+          setOpenCityDropdownId(tempId)
+          setHighlightedCityIndex(0)
+        }
+      } else if (filteredOptions.length > 0) {
+        setHighlightedCityIndex(prev => (prev + 1) % filteredOptions.length)
+      }
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      clearCityDropdownTimeout()
+      if (!isOpen) {
+        if (filteredOptions.length > 0) {
+          setOpenCityDropdownId(tempId)
+          setHighlightedCityIndex(filteredOptions.length - 1)
+        }
+      } else if (filteredOptions.length > 0) {
+        setHighlightedCityIndex(prev => (prev - 1 + filteredOptions.length) % filteredOptions.length)
+      }
+      return
+    }
+
+    if (event.key === 'Escape') {
+      if (isOpen) {
+        event.preventDefault()
+        setOpenCityDropdownId(null)
+        setHighlightedCityIndex(0)
+      }
+      return
+    }
+
+    if (event.key === 'Enter') {
+      if (isOpen && filteredOptions[highlightedCityIndex]) {
+        event.preventDefault()
+        handleCitySelect(tempId, filteredOptions[highlightedCityIndex])
+        return
+      }
+      setOpenCityDropdownId(null)
+      setHighlightedCityIndex(0)
+      handleKeyDown(event, tempId, 'city')
+      return
+    }
+
+    handleKeyDown(event, tempId, 'city')
+  }, [clearCityDropdownTimeout, handleCitySelect, handleKeyDown, highlightedCityIndex, openCityDropdownId])
 
   // Получение ошибки для ячейки
   const getCellError = useCallback((tempId: string, field: string) => {
@@ -127,6 +371,30 @@ export function BulkExpenseTable({
           <tbody>
             {expenses.map((expense, index) => {
               const tempId = expense.tempId || index.toString()
+              const cityValue = expense.city ? expense.city : ''
+              const resolvedCity = expense.city_id
+                ? cityLookupById.get(expense.city_id) ?? null
+                : resolveCityByInput(cityValue)
+              const filteredCityOptions = (() => {
+                const query = cityValue.trim().toLowerCase()
+                const base = query
+                  ? cityOptions.filter((option) =>
+                      option.cityName.toLowerCase().includes(query) ||
+                      option.synonyms.some((synonym) => synonym.toLowerCase().includes(query))
+                    )
+                  : cityOptions
+
+                return base.slice(0, 6)
+              })()
+              const resolvedMarkerPreset = resolvedCity ? normaliseMarkerPreset(resolvedCity.markerPreset) : undefined
+              const isCityDropdownOpen = openCityDropdownId === tempId
+              const cityError = getCellError(tempId, 'city')
+              const isFavoriteUpdatingForRow = resolvedCity ? favoriteMutationCityId === resolvedCity.cityId : false
+              const favoriteButtonTitleForRow = resolvedCity
+                ? resolvedCity.isFavorite
+                  ? `Убрать «${resolvedCity.cityName}» из избранного`
+                  : `Добавить «${resolvedCity.cityName}» в избранное`
+                : 'Выберите город, чтобы добавить его в избранное'
 
               return (
                 <tr key={tempId} className="hover:bg-gray-50">
@@ -194,17 +462,101 @@ export function BulkExpenseTable({
                     }}
                   >
                     <div className="space-y-1">
-                      <Input
-                        type="text"
-                        value={expense.city || ''}
-                        onChange={(e) => handleCellChange(tempId, 'city', e.target.value)}
-                        onKeyDown={(e) => handleKeyDown(e, tempId, 'city')}
-                        onFocus={() => setEditingCell(`${tempId}-city`)}
-                        className={`text-sm ${getCellError(tempId, 'city') ? 'border-red-500' : ''}`}
-                        placeholder="Город"
-                      />
-                      {getCellError(tempId, 'city') && (
-                        <ErrorMessage error={getCellError(tempId, 'city')} />
+                      <div className="relative">
+                        <Input
+                          type="text"
+                          value={cityValue}
+                          onChange={(e) => handleCityInputChange(tempId, e.target.value)}
+                          onKeyDown={(e) => handleCityKeyDown(e, tempId, filteredCityOptions)}
+                          onFocus={() => handleCityInputFocus(tempId, filteredCityOptions.length > 0)}
+                          onBlur={() => handleCityInputBlur(tempId)}
+                          className={cn(
+                            'text-sm pl-16',
+                            cityError ? 'border-red-500' : ''
+                          )}
+                          placeholder="Город"
+                        />
+                        <div className="absolute inset-y-0 left-0 flex items-center gap-1 pl-3 pr-2">
+                          <span className="pointer-events-none">
+                            <CityMarkerIcon
+                              preset={resolvedMarkerPreset}
+                              active={resolvedCity ? resolvedCity.hasCoordinates : false}
+                            />
+                          </span>
+                          <button
+                            type="button"
+                            className={cn(
+                              'rounded-md p-1 text-xs transition focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-0',
+                              resolvedCity?.isFavorite
+                                ? 'text-amber-500 hover:text-amber-600'
+                                : 'text-slate-300 hover:text-slate-400',
+                              (!resolvedCity || isFavoriteUpdatingForRow)
+                                ? 'cursor-not-allowed opacity-60 hover:text-slate-300'
+                                : 'cursor-pointer'
+                            )}
+                            onMouseDown={(event) => event.preventDefault()}
+                            onClick={() => {
+                              if (!resolvedCity || isFavoriteUpdatingForRow) {
+                                return
+                              }
+                              void handleCityFavoriteToggle(resolvedCity)
+                            }}
+                            disabled={!resolvedCity || isFavoriteUpdatingForRow}
+                            aria-pressed={resolvedCity?.isFavorite ?? false}
+                            aria-label={favoriteButtonTitleForRow}
+                            title={favoriteButtonTitleForRow}
+                          >
+                            <span className={cn(isFavoriteUpdatingForRow && 'animate-pulse')}>
+                              {resolvedCity?.isFavorite ? '★' : '☆'}
+                            </span>
+                          </button>
+                        </div>
+
+                        {isCityDropdownOpen && filteredCityOptions.length > 0 && (
+                          <div className="absolute z-30 mt-1 w-full overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg">
+                            <ul
+                              className="max-h-48 overflow-auto py-1"
+                              onMouseDown={(event) => event.preventDefault()}
+                            >
+                              {filteredCityOptions.map((option, optionIndex) => {
+                                const preset = option.markerPreset ? normaliseMarkerPreset(option.markerPreset) : undefined
+                                const secondaryLabels = option.synonyms
+                                  .filter((synonym) => synonym !== option.cityName)
+                                  .slice(0, 2)
+
+                                return (
+                                  <li key={option.cityId}>
+                                    <button
+                                      type="button"
+                                      className={cn(
+                                        'flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition',
+                                        highlightedCityIndex === optionIndex
+                                          ? 'bg-sky-50 text-sky-700'
+                                          : 'text-slate-700 hover:bg-slate-50'
+                                      )}
+                                      onMouseDown={(event) => event.preventDefault()}
+                                      onClick={() => handleCitySelect(tempId, option)}
+                                    >
+                                      <CityMarkerIcon preset={preset} active={option.hasCoordinates} />
+                                      {option.isFavorite && (
+                                        <span className="text-amber-500">★</span>
+                                      )}
+                                      <span className="flex-1 truncate">{option.cityName}</span>
+                                      {secondaryLabels.length > 0 && (
+                                        <span className="max-w-[140px] truncate text-[11px] text-slate-400">
+                                          {secondaryLabels.join(', ')}
+                                        </span>
+                                      )}
+                                    </button>
+                                  </li>
+                                )
+                              })}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                      {cityError && (
+                        <ErrorMessage error={cityError} />
                       )}
                     </div>
                   </td>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -11,8 +11,8 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ 
-    className, 
+  ({
+    className,
     type = 'text',
     label,
     error,
@@ -21,7 +21,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     rightIcon,
     variant = 'default',
     id,
-    ...props 
+    autoComplete,
+    ...props
   }, ref) => {
     const generatedId = useId()
     const inputId = id || generatedId
@@ -72,7 +73,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               className
             )}
             ref={ref}
-            autoComplete="off"
+            autoComplete={autoComplete ?? 'new-password'}
             {...props}
           />
           

--- a/src/hooks/useCitySynonyms.ts
+++ b/src/hooks/useCitySynonyms.ts
@@ -1,74 +1,101 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getCitySynonyms } from '@/lib/actions/synonyms'
 import { syncCitySynonyms } from '@/lib/utils/cityParser'
 import { parseCityCoordinates, normaliseMarkerPreset } from '@/lib/utils/cityCoordinates'
 import type { CitySynonymWithCity } from '@/types'
 
-interface CitySynonymRecord {
+export interface CitySynonymRecord {
   id: number
   cityId: string
   cityName: string
   synonym: string
   markerPreset: string | null
   hasCoordinates: boolean
+  isFavorite: boolean
 }
 
 export function useCitySynonyms() {
   const [synonyms, setSynonyms] = useState<CitySynonymRecord[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
+  const buildRecords = useCallback((data: CitySynonymWithCity[]): CitySynonymRecord[] => {
+    return data
+      .map((record) => {
+        const cityId = record.city?.id ?? record.city_id
+        const cityName = record.city?.name ?? record.synonym
+        if (!cityId) {
+          return null
+        }
+
+        const parsedCoordinates = parseCityCoordinates(record.city?.coordinates ?? null)
+
+        return {
+          id: Number(record.id),
+          cityId,
+          cityName,
+          synonym: record.synonym,
+          markerPreset: parsedCoordinates ? normaliseMarkerPreset(parsedCoordinates.markerPreset) : null,
+          hasCoordinates: Boolean(parsedCoordinates),
+          isFavorite: Boolean(record.city?.is_favorite)
+        } satisfies CitySynonymRecord
+      })
+      .filter((record): record is CitySynonymRecord => record !== null)
+  }, [])
+
+  const loadSynonyms = useCallback(async () => {
+    try {
+      const result = await getCitySynonyms()
+      if (result.success && result.data) {
+        return buildRecords(result.data as CitySynonymWithCity[])
+      }
+    } catch (error) {
+      console.error('Failed to preload city synonyms', error)
+    }
+    return null
+  }, [buildRecords])
+
   useEffect(() => {
     let isMounted = true
 
     const load = async () => {
-      try {
-        const result = await getCitySynonyms()
-        if (!isMounted) {
-          return
-        }
-
-        if (result.success && result.data) {
-          const records = (result.data as CitySynonymWithCity[])
-            .map((record) => {
-              const cityId = record.city?.id ?? record.city_id
-              const cityName = record.city?.name ?? record.synonym
-              if (!cityId) {
-                return null
-              }
-
-              const parsedCoordinates = parseCityCoordinates(record.city?.coordinates ?? null)
-
-              return {
-                id: Number(record.id),
-                cityId,
-                cityName,
-                synonym: record.synonym,
-                markerPreset: parsedCoordinates ? normaliseMarkerPreset(parsedCoordinates.markerPreset) : null,
-                hasCoordinates: Boolean(parsedCoordinates)
-              } satisfies CitySynonymRecord
-            })
-            .filter((record): record is CitySynonymRecord => record !== null)
-
-          setSynonyms(records)
-          syncCitySynonyms(records.map(record => ({ city: record.cityName, synonym: record.synonym })))
-        }
-      } catch (error) {
-        console.error('Failed to preload city synonyms', error)
-      } finally {
-        if (isMounted) {
-          setIsLoading(false)
-        }
+      setIsLoading(true)
+      const records = await loadSynonyms()
+      if (!isMounted) {
+        return
       }
+      if (records) {
+        setSynonyms(records)
+        syncCitySynonyms(records.map(record => ({ city: record.cityName, synonym: record.synonym })))
+      }
+      setIsLoading(false)
     }
 
-    load()
+    void load()
 
     return () => {
       isMounted = false
     }
+  }, [loadSynonyms])
+
+  const updateCityFavorite = useCallback((cityId: string, isFavorite: boolean) => {
+    setSynonyms(prev => prev.map(record => (
+      record.cityId === cityId
+        ? { ...record, isFavorite }
+        : record
+    )))
   }, [])
 
-  return { synonyms, isLoading }
+  const refresh = useCallback(async () => {
+    setIsLoading(true)
+    const records = await loadSynonyms()
+    if (records) {
+      setSynonyms(records)
+      syncCitySynonyms(records.map(record => ({ city: record.cityName, synonym: record.synonym })))
+    }
+    setIsLoading(false)
+  }, [loadSynonyms])
+
+  return { synonyms, isLoading, refresh, updateCityFavorite }
 }

--- a/src/lib/actions/cities.ts
+++ b/src/lib/actions/cities.ts
@@ -2,7 +2,12 @@
 
 import { revalidatePath } from 'next/cache';
 import { createServerClient } from '@/lib/supabase/server';
-import { updateCityCoordinatesSchema, type UpdateCityCoordinatesData } from '@/lib/validations/cities';
+import {
+  updateCityCoordinatesSchema,
+  toggleCityFavoriteSchema,
+  type UpdateCityCoordinatesData,
+  type ToggleCityFavoriteData
+} from '@/lib/validations/cities';
 
 export async function updateCityCoordinates(data: UpdateCityCoordinatesData) {
   const supabase = await createServerClient();
@@ -34,5 +39,40 @@ export async function updateCityCoordinates(data: UpdateCityCoordinatesData) {
   } catch (err) {
     console.error('Ошибка обновления координат города:', err);
     return { error: 'Произошла ошибка при обновлении координат' };
+  }
+}
+
+export async function toggleCityFavorite(data: ToggleCityFavoriteData) {
+  const supabase = await createServerClient();
+
+  try {
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return { error: 'Пользователь не авторизован' };
+    }
+
+    const validated = toggleCityFavoriteSchema.parse(data);
+
+    const { error } = await supabase
+      .from('cities')
+      .update({
+        is_favorite: validated.isFavorite,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', validated.id)
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Ошибка обновления избранного города:', error);
+      return { error: 'Не удалось обновить избранный город' };
+    }
+
+    revalidatePath('/settings');
+    revalidatePath('/cities');
+
+    return { success: true };
+  } catch (err) {
+    console.error('Ошибка при обновлении избранного города:', err);
+    return { error: 'Произошла ошибка при обновлении избранного города' };
   }
 }

--- a/src/lib/actions/synonyms.ts
+++ b/src/lib/actions/synonyms.ts
@@ -230,7 +230,7 @@ export async function getCitySynonyms() {
 
     const { data, error } = await supabase
       .from('city_synonyms')
-      .select('id, synonym, city_id, user_id, created_at, city:cities(id, name, coordinates)')
+      .select('id, synonym, city_id, user_id, created_at, city:cities(id, name, coordinates, is_favorite)')
       .eq('user_id', user.id);
 
     if (error) {

--- a/src/lib/validations/cities.ts
+++ b/src/lib/validations/cities.ts
@@ -10,3 +10,10 @@ export const updateCityCoordinatesSchema = z.object({
 });
 
 export type UpdateCityCoordinatesData = z.infer<typeof updateCityCoordinatesSchema>;
+
+export const toggleCityFavoriteSchema = z.object({
+  id: z.string().uuid(),
+  isFavorite: z.boolean(),
+});
+
+export type ToggleCityFavoriteData = z.infer<typeof toggleCityFavoriteSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -498,7 +498,7 @@ export type Expense = Database['public']['Tables']['expenses']['Row']
 export type City = Database['public']['Tables']['cities']['Row']
 export type CityAlias = Database['public']['Tables']['city_aliases']['Row']
 export type CitySynonym = Database['public']['Tables']['city_synonyms']['Row']
-export type CitySynonymWithCity = CitySynonym & { city: Pick<City, 'id' | 'name' | 'coordinates'> | null }
+export type CitySynonymWithCity = CitySynonym & { city: Pick<City, 'id' | 'name' | 'coordinates' | 'is_favorite'> | null }
 export type UnrecognizedCity = Database['public']['Tables']['unrecognized_cities']['Row']
 
 export type CategoryKeyword = Database['public']['Tables']['category_keywords']['Row']


### PR DESCRIPTION
## Summary
- add favorite marker toggle and prioritized sorting for city options
- reuse city synonyms in bulk entry to provide dropdown suggestions with marker and star controls
- expose toggleCityFavorite server action, schema updates, and default input autocomplete safeguards

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40c02097083209dae1e60ccb14408