### PR TITLE
Refine unrecognized city creation flow

### DIFF
--- a/src/app/(dashboard)/cities/page.tsx
+++ b/src/app/(dashboard)/cities/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { StickyPageHeader } from '@/components/layout/StickyPageHeader'
 import { CityManager } from '@/components/cities/CityManager'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
@@ -96,31 +96,31 @@ export default function CitiesPage() {
     void fetchUser()
   }, [])
 
-  useEffect(() => {
-    const loadCityExpenses = async () => {
-      setIsLoading(true)
-      setError(null)
-      try {
-        const response = await fetch(`/api/cities/expenses?period=${selectedPeriod}`, { cache: 'no-store' })
-        const payload = await response.json()
+  const loadCityExpenses = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(`/api/cities/expenses?period=${selectedPeriod}`, { cache: 'no-store' })
+      const payload = await response.json()
 
-        if (!response.ok || payload?.error) {
-          throw new Error(payload?.error ?? 'Не удалось загрузить карту расходов по городам')
-        }
-
-        const data = Array.isArray(payload?.data) ? (payload.data as CityExpenseSummary[]) : []
-        setCityExpenses(data)
-      } catch (loadError) {
-        console.error('Не удалось загрузить данные для карты расходов по городам', loadError)
-        setCityExpenses([])
-        setError(loadError instanceof Error ? loadError.message : 'Произошла ошибка при загрузке данных')
-      } finally {
-        setIsLoading(false)
+      if (!response.ok || payload?.error) {
+        throw new Error(payload?.error ?? 'Не удалось загрузить карту расходов по городам')
       }
-    }
 
-    void loadCityExpenses()
+      const data = Array.isArray(payload?.data) ? (payload.data as CityExpenseSummary[]) : []
+      setCityExpenses(data)
+    } catch (loadError) {
+      console.error('Не удалось загрузить данные для карты расходов по городам', loadError)
+      setCityExpenses([])
+      setError(loadError instanceof Error ? loadError.message : 'Произошла ошибка при загрузке данных')
+    } finally {
+      setIsLoading(false)
+    }
   }, [selectedPeriod])
+
+  useEffect(() => {
+    void loadCityExpenses()
+  }, [loadCityExpenses])
 
   useEffect(() => {
     if (citiesWithCoordinates.length === 0) {
@@ -278,7 +278,7 @@ export default function CitiesPage() {
           </CardContent>
         </Card>
 
-        <CityManager />
+        <CityManager onCityCreated={loadCityExpenses} />
       </main>
     </div>
   )

--- a/src/components/cities/CityManager.tsx
+++ b/src/components/cities/CityManager.tsx
@@ -35,6 +35,10 @@ import { CityManagerOverviewMapSection } from './CityManagerOverviewMapSection';
 import { CityManagerStatsCard } from './CityManagerStatsCard';
 import type { CityGroup, CityGroupWithCoordinates, CitySynonymRecord } from './cityManagerTypes';
 
+interface CityManagerProps {
+  onCityCreated?: () => Promise<void> | void;
+}
+
 const pickRandomMarkerPreset = (exclude?: string) => {
   if (MARKER_PRESETS.length === 0) {
     return DEFAULT_MARKER_PRESET;
@@ -60,7 +64,7 @@ const pickRandomMarkerPreset = (exclude?: string) => {
   return candidate;
 };
 
-export function CityManager() {
+export function CityManager({ onCityCreated }: CityManagerProps = {}) {
   const [synonyms, setSynonyms] = useState<CitySynonymRecord[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [newCity, setNewCity] = useState('')
@@ -87,7 +91,8 @@ export function CityManager() {
   const [selectedCoordinates, setSelectedCoordinates] = useState<CityCoordinates | null>(null)
   const [manualLat, setManualLat] = useState('')
   const [manualLon, setManualLon] = useState('')
-  const [newCitySynonym, setNewCitySynonym] = useState('')
+  const [useUnrecognizedAlternate, setUseUnrecognizedAlternate] = useState(false)
+  const newCityInputRef = useRef<HTMLInputElement | null>(null)
   const [isSearchingCoordinates, setIsSearchingCoordinates] = useState(false)
   const mapRef = useRef<unknown>(null)
   const overviewMapRef = useRef<unknown>(null)
@@ -397,6 +402,16 @@ export function CityManager() {
     }
   }, [selectedUnrecognizedCityId, selectedUnrecognizedCity])
 
+  useEffect(() => {
+    if (!useUnrecognizedAlternate) {
+      return
+    }
+
+    if (!selectedUnrecognizedCity?.name) {
+      setUseUnrecognizedAlternate(false)
+    }
+  }, [selectedUnrecognizedCity, useUnrecognizedAlternate])
+
   const citySelectionOptions = useMemo<SelectOption[]>(
     () =>
       groupedSynonyms.map(group => ({
@@ -480,16 +495,10 @@ export function CityManager() {
       setSelectedAttachCityId(null)
 
       if (!value) {
-        setNewCitySynonym('')
-        return
-      }
-
-      const city = unrecognizedCities.find(item => item.id === value)
-      if (city?.name) {
-        setNewCitySynonym(city.name)
+        setUseUnrecognizedAlternate(false)
       }
     },
-    [unrecognizedCities]
+    []
   )
 
   const handleUseUnrecognizedCity = useCallback(() => {
@@ -498,14 +507,16 @@ export function CityManager() {
       return
     }
     setNewCity(selectedUnrecognizedCity.name)
-    setNewCitySynonym(selectedUnrecognizedCity.name)
+    requestAnimationFrame(() => {
+      newCityInputRef.current?.focus()
+    })
     geocodeCity(selectedUnrecognizedCity.name, { silent: true, force: true })
   }, [geocodeCity, selectedUnrecognizedCity, showToast])
 
   const handleClearUnrecognizedSelection = useCallback(() => {
     setSelectedUnrecognizedCityId(null)
     setSelectedAttachCityId(null)
-    setNewCitySynonym('')
+    setUseUnrecognizedAlternate(false)
   }, [])
 
   const handleSelectAttachCity = useCallback((value: string | null) => {
@@ -516,9 +527,24 @@ export function CityManager() {
     setNewCity(value)
   }, [])
 
-  const handleAlternateCityChange = useCallback((value: string) => {
-    setNewCitySynonym(value)
-  }, [])
+  const handleToggleUseUnrecognizedAlternate = useCallback(
+    (nextValue: boolean) => {
+      if (nextValue) {
+        if (!selectedUnrecognizedCity?.name) {
+          showToast('Выберите непознанный город, чтобы использовать его как альтернативное название', 'warning')
+          return
+        }
+        setUseUnrecognizedAlternate(true)
+        requestAnimationFrame(() => {
+          newCityInputRef.current?.focus()
+        })
+        return
+      }
+
+      setUseUnrecognizedAlternate(false)
+    },
+    [selectedUnrecognizedCity, showToast]
+  )
 
   const handleFindCityOnMap = useCallback(() => {
     if (!newCity.trim()) {
@@ -680,27 +706,21 @@ export function CityManager() {
         let effectiveCoordinates: CityCoordinates | null = selectedCoordinates
 
         const additionalSynonyms = (() => {
-          const collected = new Map<string, string>()
-          const normalizedCity = cityName.toLocaleLowerCase('ru')
-
-          const register = (value: string | null | undefined) => {
-            const trimmed = value?.trim()
-            if (!trimmed) {
-              return
-            }
-            const normalized = trimmed.toLocaleLowerCase('ru')
-            if (normalized === normalizedCity) {
-              return
-            }
-            if (!collected.has(normalized)) {
-              collected.set(normalized, trimmed)
-            }
+          if (!useUnrecognizedAlternate) {
+            return []
           }
 
-          register(newCitySynonym)
-          register(selectedUnrecognizedCity?.name)
+          const alternative = selectedUnrecognizedCity?.name?.trim()
+          if (!alternative) {
+            return []
+          }
 
-          return Array.from(collected.values())
+          const normalizedCity = cityName.toLocaleLowerCase('ru')
+          if (alternative.toLocaleLowerCase('ru') === normalizedCity) {
+            return []
+          }
+
+          return [alternative]
         })()
 
         if (createdCityId && !coordinatesAreEqual(selectedCoordinates, serverCoordinates)) {
@@ -769,9 +789,17 @@ export function CityManager() {
           await loadUnrecognizedCities()
         }
 
+        if (onCityCreated) {
+          try {
+            await onCityCreated()
+          } catch (refreshError) {
+            console.error('Не удалось обновить карту расходов после добавления города', refreshError)
+          }
+        }
+
         showToast('Город добавлен', 'success')
         setNewCity('')
-        setNewCitySynonym('')
+        setUseUnrecognizedAlternate(false)
         resetSelection()
       }
     } catch (error) {
@@ -940,6 +968,8 @@ export function CityManager() {
                     selectedUnrecognizedCity={selectedUnrecognizedCity}
                     onClearUnrecognizedSelection={handleClearUnrecognizedSelection}
                     onUseUnrecognizedCity={handleUseUnrecognizedCity}
+                    useUnrecognizedAlternate={useUnrecognizedAlternate}
+                    onToggleUseUnrecognizedAlternate={handleToggleUseUnrecognizedAlternate}
                     citySelectionOptions={citySelectionOptions}
                     selectedAttachCityId={selectedAttachCityId}
                     onSelectAttachCity={handleSelectAttachCity}
@@ -950,8 +980,8 @@ export function CityManager() {
                   <CityManagerCreateCitySection
                     newCity={newCity}
                     onCityChange={handleCityNameChange}
-                    alternateCity={newCitySynonym}
-                    onAlternateCityChange={handleAlternateCityChange}
+                    newCityInputRef={newCityInputRef}
+                    useUnrecognizedAlternate={useUnrecognizedAlternate}
                     isSubmitting={isSubmitting}
                     onFindOnMap={handleFindCityOnMap}
                     isSearchingCoordinates={isSearchingCoordinates}

--- a/src/components/cities/CityManagerCreateCitySection.tsx
+++ b/src/components/cities/CityManagerCreateCitySection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { RefObject } from 'react';
 import { Button, Input } from '@/components/ui';
 import { MarkerPresetPicker } from '@/components/cities/MarkerPresetPicker';
 import { YMaps, Map as YandexMap, Placemark } from '@pbe/react-yandex-maps';
@@ -10,8 +11,8 @@ import { extractEventCoordinates, extractPlacemarkCoordinates, type MapState } f
 interface CityManagerCreateCitySectionProps {
   newCity: string;
   onCityChange: (value: string) => void;
-  alternateCity: string;
-  onAlternateCityChange: (value: string) => void;
+  newCityInputRef: RefObject<HTMLInputElement | null>;
+  useUnrecognizedAlternate: boolean;
   isSubmitting: boolean;
   onFindOnMap: () => void;
   isSearchingCoordinates: boolean;
@@ -33,8 +34,8 @@ interface CityManagerCreateCitySectionProps {
 export function CityManagerCreateCitySection({
   newCity,
   onCityChange,
-  alternateCity,
-  onAlternateCityChange,
+  newCityInputRef,
+  useUnrecognizedAlternate,
   isSubmitting,
   onFindOnMap,
   isSearchingCoordinates,
@@ -52,6 +53,10 @@ export function CityManagerCreateCitySection({
   onManualBlur,
   onManualApply,
 }: CityManagerCreateCitySectionProps) {
+  const submitLabel = useUnrecognizedAlternate
+    ? 'Добавить город вместе с его альтернативным названием'
+    : 'Добавить город';
+
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:gap-2">
@@ -68,6 +73,7 @@ export function CityManagerCreateCitySection({
               disabled={isSubmitting}
               className="h-11 pl-12"
               autoComplete="new-password"
+              ref={newCityInputRef}
             />
             <MarkerPresetPicker
               value={selectedMarkerPreset}
@@ -78,24 +84,7 @@ export function CityManagerCreateCitySection({
             />
           </div>
         </div>
-        <div className="flex-grow space-y-2">
-          <label
-            className="block text-xs font-semibold uppercase tracking-wide text-slate-500"
-            htmlFor="synonym-alternate"
-          >
-            Альтернативное название
-          </label>
-          <Input
-            id="synonym-alternate"
-            placeholder="Например: Питер"
-            value={alternateCity}
-            onChange={event => onAlternateCityChange(event.target.value)}
-            disabled={isSubmitting}
-            className="h-11"
-            autoComplete="new-password"
-          />
-        </div>
-        <div className="flex flex-shrink-0 gap-2">
+        <div className="flex flex-shrink-0 gap-2 sm:self-end">
           <Button
             type="button"
             variant="outline"
@@ -106,8 +95,13 @@ export function CityManagerCreateCitySection({
           >
             Найти на карте
           </Button>
-          <Button type="submit" isLoading={isSubmitting} disabled={isSubmitting || !selectedCoordinates} className="h-11">
-            Добавить город
+          <Button
+            type="submit"
+            isLoading={isSubmitting}
+            disabled={isSubmitting || !selectedCoordinates}
+            className="h-11 text-center leading-snug"
+          >
+            {submitLabel}
           </Button>
         </div>
       </div>

--- a/src/components/cities/CityManagerUnrecognizedPanel.tsx
+++ b/src/components/cities/CityManagerUnrecognizedPanel.tsx
@@ -16,6 +16,8 @@ interface CityManagerUnrecognizedPanelProps {
   selectedUnrecognizedCity: UnrecognizedCity | null;
   onClearUnrecognizedSelection: () => void;
   onUseUnrecognizedCity: () => void;
+  useUnrecognizedAlternate: boolean;
+  onToggleUseUnrecognizedAlternate: (value: boolean) => void;
   citySelectionOptions: SelectOption[];
   selectedAttachCityId: string | null;
   onSelectAttachCity: (value: string | null) => void;
@@ -32,6 +34,8 @@ export function CityManagerUnrecognizedPanel({
   selectedUnrecognizedCity,
   onClearUnrecognizedSelection,
   onUseUnrecognizedCity,
+  useUnrecognizedAlternate,
+  onToggleUseUnrecognizedAlternate,
   citySelectionOptions,
   selectedAttachCityId,
   onSelectAttachCity,
@@ -49,7 +53,7 @@ export function CityManagerUnrecognizedPanel({
         onChange={onSelectUnrecognizedCity}
         placeholder={isLoadingUnrecognized ? 'Загружаем список…' : 'Выберите город из расходов'}
         className="w-full"
-        disabled={isLoadingUnrecognized || isSubmitting}
+        disabled={isLoadingUnrecognized || isSubmitting || useUnrecognizedAlternate}
         maxVisibleOptions={3}
         forceOpen
       />
@@ -71,7 +75,7 @@ export function CityManagerUnrecognizedPanel({
             </div>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-4">
-            <div className="flex flex-col items-center justify-center rounded-lg border bg-slate-50/50 p-4">
+            <div className="space-y-3 rounded-lg border bg-slate-50/50 p-4">
               <Button
                 type="button"
                 variant="outline"
@@ -81,6 +85,18 @@ export function CityManagerUnrecognizedPanel({
               >
                 Использовать как новый город
               </Button>
+              <label className="flex cursor-pointer items-start gap-2 text-xs text-slate-600">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  checked={useUnrecognizedAlternate}
+                  onChange={(event) => onToggleUseUnrecognizedAlternate(event.target.checked)}
+                  disabled={!selectedUnrecognizedCity || isSubmitting}
+                />
+                <span className="leading-snug">
+                  Добавить «{selectedUnrecognizedCity?.name ?? '—'}» как альтернативное название для нового города
+                </span>
+              </label>
             </div>
             <div className="space-y-3 rounded-lg border bg-slate-50/50 p-4">
               <p className="text-center text-xs font-semibold uppercase tracking-wide text-slate-500">


### PR DESCRIPTION
## Summary
- move the alternate-name checkbox into the unrecognized city panel, disable the picker when active, and focus the new city input automatically
- simplify the city creation form by removing the redundant alternate-name input and updating the submit copy when the checkbox is enabled
- only enqueue the selected unrecognized name as an extra synonym when the checkbox is on so the new city carries the alternative label on creation

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e346daec8320ad404e54bb0f8409