### PR TITLE
Refactor: modularize bulk expense input

### DIFF
--- a/src/components/expense-input/bulk-input/BulkExpenseInput.tsx
+++ b/src/components/expense-input/bulk-input/BulkExpenseInput.tsx
@@ -1,182 +1,40 @@
 'use client'
 
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
-import { Modal } from '@/components/ui/Modal'
-import { useToast } from '@/hooks/useToast'
 import { BulkExpenseTable } from './BulkExpenseTable'
-import { BulkExpensePreview } from './BulkExpensePreview'
 import { ColumnMappingModal } from './ColumnMappingModal'
-
-import { createBulkExpenses } from '@/lib/actions/expenses'
-import { createBankStatement } from '@/lib/actions/bankStatements'
-import { getCurrentDateISO } from '@/lib/utils/dateUtils'
-import {
-  parseBankStatementFile,
-  analyzeHTML,
-  parseDateAndTime,
-  parseCSV,
-  parseHTML,
-  parseAmount,
-  parseTimeValue
-} from '@/lib/utils/bankStatementParsers'
-import { extractCityFromDescription } from '@/lib/utils/cityParser'
-import type {
-  Category,
-  CreateExpenseData,
-  ColumnMapping,
-  ColumnMappingField,
-  ParsedBankData
-} from '@/types'
-import type { BulkExpenseRowData } from '@/lib/validations/expenses'
-import type { TableInfo } from '@/lib/utils/bankStatementParsers'
+import { HowToUse } from './HowToUse'
+import { Dropzone } from './components/Dropzone'
+import { ReviewModal } from './components/ReviewModal'
+import { TableSelectionModal } from './components/TableSelectionModal'
+import { TablePreviewModal } from './components/TablePreviewModal'
 import { useCitySynonyms } from '@/hooks/useCitySynonyms'
-import { buildCityOptions, type CityOption } from '@/lib/utils/cityOptions'
-
-type SelectedTableMeta = Pick<
-  TableInfo,
-  'index' | 'description' | 'rowCount' | 'columnCount' | 'hasHeaders'
->
-
-const HEADER_KEYWORDS = [
-  'amount',
-  'сумм',
-  'sum',
-  'debet',
-  'credit',
-  'дата',
-  'date',
-  'опис',
-  'description',
-  'city',
-  'город',
-  'time',
-  'время',
-  'note',
-  'примеч'
-]
-
-type AutoExtractionReviewItem = {
-  type: 'city-from-description'
-  rowIndex: number
-  columnLabel: string
-  sourceValue: string
-  extractedCity: string
-  cleanedDescription: string
-}
-
-type CityReviewItem = AutoExtractionReviewItem
-
-interface BuildExpensesStats {
-  totalRows: number
-  importedRows: number
-  skippedRows: number
-  autoDetectedCities: number
-  manualCities: number
-  detectedTimes: number
-  manualTimes: number
-}
-
-interface BuildExpensesResult {
-  expenses: BulkExpenseRowData[]
-  stats: BuildExpensesStats
-  reviewItems: AutoExtractionReviewItem[]
-}
-
-function normalizeRow(row: string[] = []): string[] {
-  return row.map(cell => (cell ?? '').trim())
-}
-
-function removeEmptyRows(rows: string[][], preserveFirstRow = false): string[][] {
-  return rows.filter((row, index) => {
-    if (preserveFirstRow && index === 0) {
-      return true
-    }
-    return row.some(cell => cell && cell.trim().length > 0)
-  })
-}
-
-function detectHeaderRow(headerRow: string[], firstDataRow?: string[]): boolean {
-  if (!headerRow || headerRow.length === 0) {
-    return false
-  }
-
-  const normalizedHeader = headerRow.map(cell => cell.trim().toLowerCase())
-  const headerHasKeywords = normalizedHeader.some(cell =>
-    HEADER_KEYWORDS.some(keyword => cell.includes(keyword))
-  )
-  if (headerHasKeywords) {
-    return true
-  }
-
-  const headerHasDigits = headerRow.some(cell => /\d/.test(cell))
-  const dataHasDigits = firstDataRow ? firstDataRow.some(cell => /\d/.test(cell)) : false
-
-  return !headerHasDigits && dataHasDigits
-}
-
-function prepareParsedDataset(parsed: ParsedBankData): { rows: string[][]; hasHeader: boolean } {
-  const headerRow = normalizeRow(parsed.headers || [])
-  const dataRows = (parsed.rows || []).map(normalizeRow)
-  const firstDataRow = dataRows[0]
-
-  const headerHasContent = headerRow.some(cell => cell.length > 0)
-  const hasHeader = headerHasContent && detectHeaderRow(headerRow, firstDataRow)
-
-  if (hasHeader) {
-    return {
-      rows: removeEmptyRows([headerRow, ...dataRows], true),
-      hasHeader: true
-    }
-  }
-
-  if (headerHasContent) {
-    return {
-      rows: removeEmptyRows([headerRow, ...dataRows]),
-      hasHeader: false
-    }
-  }
-
-  return {
-    rows: removeEmptyRows(dataRows),
-    hasHeader: false
-  }
-}
+import { buildCityOptions } from '@/lib/utils/cityOptions'
+import type { Category, ColumnMapping } from '@/types'
+import type { BuildExpensesResult } from './types'
+import { useExpenseBuilder } from './useExpenseBuilder'
+import { useFileHandler } from './useFileHandler'
+import { useColumnMapping } from './useColumnMapping'
+import { useExpenseSubmit } from './useExpenseSubmit'
 
 interface BulkExpenseInputProps {
   categories: Category[]
 }
 
 export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
-  const [expenses, setExpenses] = useState<BulkExpenseRowData[]>([])
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
-  const [isColumnMappingOpen, setIsColumnMappingOpen] = useState(false)
   const [pastedData, setPastedData] = useState<string[][]>([])
   const [hasHeaderRow, setHasHeaderRow] = useState(false)
-  const [autoRedirect, setAutoRedirect] = useState(false) // Изначально выключен
-  const [savedColumnMapping, setSavedColumnMapping] = useState<ColumnMapping[] | null>(null)
+  const [isColumnMappingOpen, setIsColumnMappingOpen] = useState(false)
   const [isEditingColumnMapping, setIsEditingColumnMapping] = useState(false)
-  const [isMounted, setIsMounted] = useState(false)
-  const [showTableSelection, setShowTableSelection] = useState(false)
-  const [availableTables, setAvailableTables] = useState<TableInfo[]>([])
-  const [fileContent, setFileContent] = useState<string | null>(null)
-  const [fileName, setFileName] = useState<string>('')
-  const [savedTableIndex, setSavedTableIndex] = useState<number | null>(null)
-  const [selectedTableMeta, setSelectedTableMeta] = useState<SelectedTableMeta | null>(null)
+  const [autoRedirect, setAutoRedirect] = useState(false)
   const [reviewModalState, setReviewModalState] = useState<{
     mode: 'append' | 'directSave'
     result: BuildExpensesResult
   } | null>(null)
-  const [isReviewProcessing, setIsReviewProcessing] = useState(false)
-  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
-  const [previewedTable, setPreviewedTable] = useState<{ description: string; rows: string[][] } | null>(null);
-  const [isFileLoading, setIsFileLoading] = useState(false)
-  const { showToast } = useToast()
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const router = useRouter()
+  const [isMounted, setIsMounted] = useState(false)
+
   const { synonyms: citySynonyms } = useCitySynonyms()
 
   const { cityOptions, cityLookupBySynonym, cityLookupById } = useMemo(
@@ -185,7 +43,7 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
   )
 
   const resolveCityByInput = useCallback(
-    (value: string): CityOption | null => {
+    (value: string) => {
       const normalized = value.trim().toLowerCase()
       if (!normalized) {
         return null
@@ -195,643 +53,112 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
     [cityLookupBySynonym]
   )
 
-  // Загрузка сохраненной схемы столбцов при инициализации
-  const loadSavedColumnMapping = useCallback(() => {
-    try {
-      const saved = localStorage.getItem('bulkExpenseColumnMapping')
-      if (saved) {
-        const parsed = JSON.parse(saved)
-        const normalized = normalizeColumnMapping(parsed)
-        setSavedColumnMapping(normalized.length > 0 ? normalized : null)
-        return normalized
+  const handleDatasetClear = useCallback(() => {
+    setPastedData([])
+    setHasHeaderRow(false)
+    setIsColumnMappingOpen(false)
+    setIsEditingColumnMapping(false)
+  }, [])
+
+  const {
+    expenses,
+    validationErrors,
+    addRow,
+    removeRow,
+    updateRow,
+    handleClear,
+    validateExpenses,
+    appendSingleColumnExpenses,
+    buildExpensesFromMappedData,
+    appendExpensesWithStats
+  } = useExpenseBuilder({
+    pastedData,
+    hasHeaderRow,
+    resolveCityByInput,
+    onDatasetConsumed: handleDatasetClear
+  })
+
+  const {
+    fileInputRef,
+    isFileLoading,
+    fileName,
+    fileContent,
+    availableTables,
+    showTableSelection,
+    setShowTableSelection,
+    selectedTableMeta,
+    savedTableIndex,
+    isDragOver,
+    isPreviewModalOpen,
+    setIsPreviewModalOpen,
+    previewedTable,
+    loadSavedTableIndex,
+    clearSavedTableIndex,
+    handleFileUpload,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleTableSelection,
+    handlePreviewTable,
+    handleFileStateReset
+  } = useFileHandler({
+    appendSingleColumnExpenses,
+    onDatasetReady: (data, hasHeader) => {
+      setPastedData(data)
+      setHasHeaderRow(hasHeader)
+      setIsEditingColumnMapping(false)
+      setIsColumnMappingOpen(true)
+    },
+    resetDataset: handleDatasetClear,
+    setIsColumnMappingOpen,
+    setIsEditingColumnMapping
+  })
+
+  const onDatasetSaved = useCallback((_result: BuildExpensesResult) => {
+    handleDatasetClear()
+    handleFileStateReset()
+  }, [handleDatasetClear, handleFileStateReset])
+
+  const {
+    isSubmitting,
+    isReviewProcessing,
+    handleDirectSave,
+    saveImportedExpenses
+  } = useExpenseSubmit({
+    expenses,
+    autoRedirect,
+    validateExpenses,
+    clearExpenses: handleClear,
+    resetFileState: handleFileStateReset,
+    onDatasetSaved,
+    fileName
+  })
+
+  const {
+    savedColumnMapping,
+    loadSavedColumnMapping,
+    handleColumnMappingApply,
+    handleColumnMappingApplyAndSave
+  } = useColumnMapping({
+    buildExpensesFromMappedData,
+    appendExpensesWithStats,
+    saveImportedExpenses: async (result: BuildExpensesResult) => {
+      const success = await saveImportedExpenses(result)
+      if (success) {
+        setReviewModalState(null)
       }
-    } catch (error) {
-      console.warn('Ошибка загрузки сохраненной схемы столбцов:', error)
-    }
-    setSavedColumnMapping(null)
-    return []
-  }, [])
+      return success
+    },
+    setReviewModalState,
+    isEditingColumnMapping
+  })
 
-  // Сохранение схемы столбцов
-  const saveColumnMapping = useCallback((mapping: ColumnMapping[]) => {
-    try {
-      const sanitized = sanitizeColumnMapping(mapping)
-      localStorage.setItem('bulkExpenseColumnMapping', JSON.stringify(sanitized))
-      setSavedColumnMapping(sanitized.length > 0 ? sanitized : null)
-    } catch (error) {
-      console.warn('Ошибка сохранения схемы столбцов:', error)
-    }
-  }, [])
-
-  // Загрузка сохраненного индекса таблицы
-  const loadSavedTableIndex = useCallback(() => {
-    try {
-      const saved = localStorage.getItem('bulkExpenseTableIndex')
-      if (saved) {
-        const tableIndex = parseInt(saved, 10)
-        setSavedTableIndex(tableIndex)
-        return tableIndex
-      }
-    } catch (error) {
-      console.warn('Ошибка загрузки сохраненного индекса таблицы:', error)
-    }
-    return null
-  }, [])
-
-  // Сохранение индекса таблицы
-  const saveTableIndex = useCallback((tableIndex: number) => {
-    try {
-      localStorage.setItem('bulkExpenseTableIndex', tableIndex.toString())
-      setSavedTableIndex(tableIndex)
-    } catch (error) {
-      console.warn('Ошибка сохранения индекса таблицы:', error)
-    }
-  }, [])
-
-  const clearSavedTableIndex = useCallback(() => {
-    try {
-      localStorage.removeItem('bulkExpenseTableIndex')
-      setSavedTableIndex(null)
-      setSelectedTableMeta(null)
-    } catch (error) {
-      console.warn('Ошибка очистки индекса таблицы:', error)
-    }
-  }, [])
-
-  // Загружаем сохраненные настройки при первом рендере
   useEffect(() => {
     setIsMounted(true)
     loadSavedColumnMapping()
     loadSavedTableIndex()
   }, [loadSavedColumnMapping, loadSavedTableIndex])
-
-  // Добавить новую строку
-  const addRow = useCallback(() => {
-    const newRow: BulkExpenseRowData = {
-      amount: 0,
-      description: '',
-      notes: '',
-      category_id: '',
-      expense_date: getCurrentDateISO(),
-      expense_time: '',
-      city: '',
-      city_id: null,
-      tempId: crypto.randomUUID()
-    }
-    setExpenses(prev => [...prev, newRow])
-  }, [])
-
-  // Удалить строку
-  const removeRow = useCallback((tempId: string) => {
-    setExpenses(prev => prev.filter(expense => expense.tempId !== tempId))
-    setValidationErrors(prev => {
-      const newErrors = { ...prev }
-      Object.keys(newErrors).forEach(key => {
-        if (key.startsWith(`${tempId}-`)) {
-          delete newErrors[key]
-        }
-      })
-      return newErrors
-    })
-  }, [])
-
-  // Обновить строку
-  const updateRow = useCallback((tempId: string, field: keyof BulkExpenseRowData, value: any) => {
-    setExpenses(prev => prev.map(expense =>
-      expense.tempId === tempId
-        ? { ...expense, [field]: value }
-        : expense
-    ))
-
-    // Очистить ошибку валидации для этого поля
-    const errorKey = `${tempId}-${field}`
-    if (validationErrors[errorKey]) {
-      setValidationErrors(prev => {
-        const newErrors = { ...prev }
-        delete newErrors[errorKey]
-        return newErrors
-      })
-    }
-  }, [validationErrors])
-
-  // Валидация данных
-  const validateExpenses = useCallback(() => {
-    const errors: Record<string, string> = {}
-    let hasErrors = false
-
-    expenses.forEach((expense, index) => {
-      const prefix = expense.tempId || index.toString()
-
-      if (!expense.amount || expense.amount <= 0) {
-        errors[`${prefix}-amount`] = 'Сумма должна быть больше 0'
-        hasErrors = true
-      }
-
-      if (!expense.description?.trim()) {
-        errors[`${prefix}-description`] = 'Описание обязательно'
-        hasErrors = true
-      }
-
-      if (!expense.expense_date) {
-        errors[`${prefix}-expense_date`] = 'Дата обязательна'
-        hasErrors = true
-      }
-
-      if (expense.expense_time && expense.expense_time.trim()) {
-        const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/
-        if (!timeRegex.test(expense.expense_time.trim())) {
-          errors[`${prefix}-expense_time`] = 'Время должно быть в формате ЧЧ:ММ'
-          hasErrors = true
-        }
-      }
-    })
-
-    setValidationErrors(errors)
-    return !hasErrors
-  }, [expenses])
-
-  const appendSingleColumnExpenses = useCallback((rows: string[][], hasHeader: boolean, sourceLabel: string) => {
-    const dataRows = (hasHeader ? rows.slice(1) : rows)
-      .map(normalizeRow)
-      .filter(row => row[0] && row[0].trim())
-
-    if (dataRows.length === 0) {
-      showToast('Не найдены значения для описания', 'warning')
-      return 0
-    }
-
-    const newExpenses: BulkExpenseRowData[] = dataRows.map(row => ({
-      amount: 0,
-      description: row[0].trim(),
-      city: '',
-      city_id: null,
-      notes: '',
-      category_id: '',
-      expense_date: getCurrentDateISO(),
-      expense_time: '',
-      tempId: crypto.randomUUID()
-    }))
-
-    setExpenses(prev => [...prev, ...newExpenses])
-    showToast(`Добавлено ${newExpenses.length} описаний из ${sourceLabel}`, 'success')
-    return newExpenses.length
-  }, [showToast])
-
-  // Обработка вставки из буфера обмена
-  const handlePaste = useCallback(async (event: React.ClipboardEvent) => {
-    event.preventDefault()
-
-    setSelectedTableMeta(null)
-    setAvailableTables([])
-    setFileContent(null)
-    setFileName('')
-
-    try {
-      const htmlData = event.clipboardData.getData('text/html')
-      if (htmlData && htmlData.includes('<table')) {
-        try {
-          const parsedFromHtml = parseHTML(htmlData)
-          const prepared = prepareParsedDataset(parsedFromHtml)
-          const dataset = prepared.rows
-
-          if (dataset.length === 0) {
-            showToast('Вставленная таблица не содержит данных', 'error')
-            return
-          }
-
-          const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
-          if (dataRows.length === 0) {
-            showToast('Вставленная таблица содержит только заголовки', 'warning')
-            return
-          }
-
-          if (dataRows[0].length > 1) {
-            setPastedData(dataset)
-            setHasHeaderRow(prepared.hasHeader)
-            setIsEditingColumnMapping(false)
-            setIsColumnMappingOpen(true)
-            showToast(`Обнаружена таблица (${dataRows.length} строк). Назначьте столбцы и проверьте данные.`, 'success')
-            return
-          }
-
-          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'вставленной таблицы')
-          setHasHeaderRow(false)
-          return
-        } catch (htmlError) {
-          console.warn('Не удалось обработать HTML из буфера обмена', htmlError)
-        }
-      }
-
-      const pastedText = event.clipboardData.getData('text')
-      if (!pastedText) {
-        showToast('Буфер обмена пуст', 'warning')
-        return
-      }
-
-      const parsed = parseCSV(pastedText)
-      const prepared = prepareParsedDataset(parsed)
-      const dataset = prepared.rows
-
-      if (dataset.length === 0) {
-        showToast('Вставленные данные пусты', 'error')
-        return
-      }
-
-      const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
-      if (dataRows.length === 0) {
-        showToast('Не найдены строки с данными', 'error')
-        return
-      }
-
-      if (dataRows[0].length > 1) {
-        setPastedData(dataset)
-        setHasHeaderRow(prepared.hasHeader)
-        setIsEditingColumnMapping(false)
-        setIsColumnMappingOpen(true)
-        showToast(`Получены данные (${dataRows.length} строк). Проверьте соответствие столбцов.`, 'success')
-        return
-      }
-
-      appendSingleColumnExpenses(dataset, prepared.hasHeader, 'буфера обмена')
-      setHasHeaderRow(false)
-    } catch (error) {
-      console.error('Ошибка при вставке данных', error)
-      showToast('Ошибка при вставке данных', 'error')
-    }
-  }, [showToast, appendSingleColumnExpenses])
-
-
-
-  const buildExpensesFromMappedData = useCallback((mapping: ColumnMapping[]): BuildExpensesResult => {
-    const stats: BuildExpensesStats = {
-      totalRows: 0,
-      importedRows: 0,
-      skippedRows: 0,
-      autoDetectedCities: 0,
-      manualCities: 0,
-      detectedTimes: 0,
-      manualTimes: 0
-    }
-
-    if (pastedData.length === 0) {
-      return { expenses: [] as BulkExpenseRowData[], stats, reviewItems: [] }
-    }
-
-    const headerRow = hasHeaderRow ? pastedData[0] : null
-    const getColumnLabel = (index: number) => {
-      const headerValue = headerRow?.[index]?.trim()
-      if (headerValue) {
-        return headerValue
-      }
-
-      if (index >= 0 && index < 26) {
-        return `Столбец ${String.fromCharCode(65 + index)}`
-      }
-
-      return `Столбец ${index + 1}`
-    }
-
-    const mappingWithMeta = sanitizeColumnMapping(mapping).map((column, columnIndex) => ({
-      ...column,
-      columnIndex,
-      columnLabel: getColumnLabel(columnIndex),
-      targetFields: Array.isArray(column.targetFields)
-        ? column.targetFields.filter(isColumnMappingField)
-        : [],
-      hidden: Boolean(column.hidden)
-    }))
-
-    const rowsToProcess = (hasHeaderRow ? pastedData.slice(1) : pastedData)
-      .map(normalizeRow)
-      .filter(row => row.some(cell => cell && cell.trim().length > 0))
-
-    stats.totalRows = rowsToProcess.length
-
-    const newExpenses: BulkExpenseRowData[] = []
-    const reviewItems: AutoExtractionReviewItem[] = []
-
-    rowsToProcess.forEach((row, dataRowIndex) => {
-      const expenseData: Partial<BulkExpenseRowData> & { expense_time?: string | null } = {
-        tempId: crypto.randomUUID()
-      }
-
-      let descriptionColumnLabel: string | null = null
-      let descriptionSourceValue = ''
-      let descriptionColumnIndex: number | null = null
-
-      mappingWithMeta.forEach(column => {
-        if (column.hidden) {
-          return
-        }
-
-        if (!column.enabled || column.targetFields.length === 0) return
-
-        const cellValue = row[column.columnIndex]?.trim() || ''
-        if (!cellValue) return
-
-        column.targetFields.forEach(targetField => {
-          switch (targetField) {
-            case 'amount': {
-              try {
-                const parsedAmount = parseAmount(cellValue)
-                const normalizedAmount = Math.abs(parsedAmount)
-                if (normalizedAmount > 0) {
-                  expenseData.amount = normalizedAmount
-                }
-              } catch (error) {
-                console.warn('Не удалось распарсить сумму из столбца', cellValue, error)
-              }
-              break
-            }
-            case 'description':
-              expenseData.description = cellValue
-              descriptionColumnLabel = column.columnLabel
-              descriptionSourceValue = cellValue
-              descriptionColumnIndex = column.columnIndex
-              break
-            case 'city':
-              expenseData.city = cellValue
-              break
-            case 'expense_date': {
-              const dateTimeResult = parseDateAndTime(cellValue)
-              expenseData.expense_date = dateTimeResult.date
-              if (dateTimeResult.time && !expenseData.expense_time) {
-                expenseData.expense_time = dateTimeResult.time
-                stats.detectedTimes += 1
-              }
-              break
-            }
-            case 'expense_time': {
-              if (expenseData.expense_time) {
-                break
-              }
-              const parsedTime = parseTimeValue(cellValue)
-              if (parsedTime) {
-                expenseData.expense_time = parsedTime
-                stats.manualTimes += 1
-              }
-              break
-            }
-            case 'notes':
-              expenseData.notes = cellValue
-              break
-          }
-        })
-      })
-
-      if (expenseData.amount && expenseData.description) {
-        let cleanDescription = expenseData.description.trim()
-        let notes = expenseData.notes?.trim() || ''
-        let detectedCity: string | null = null
-
-        if (cleanDescription) {
-          const cityParseResult = extractCityFromDescription(cleanDescription)
-          if (cityParseResult.confidence > 0.6) {
-            cleanDescription = cityParseResult.cleanDescription
-            if (!expenseData.city && cityParseResult.displayCity) {
-              detectedCity = cityParseResult.displayCity
-            }
-          }
-        }
-
-        const providedCity = expenseData.city?.trim()
-        let finalCity = providedCity || detectedCity || ''
-        let resolvedCityId: string | null = null
-
-        if (providedCity) {
-          stats.manualCities += 1
-          const resolved = resolveCityByInput(providedCity)
-          if (resolved) {
-            finalCity = resolved.cityName
-            resolvedCityId = resolved.cityId
-          }
-        } else if (detectedCity) {
-          stats.autoDetectedCities += 1
-          const resolved = resolveCityByInput(detectedCity)
-          if (resolved) {
-            finalCity = resolved.cityName
-            resolvedCityId = resolved.cityId
-          }
-          const reviewNote = `Автодетект города: ${finalCity || detectedCity}`
-          if (!notes.includes(reviewNote)) {
-            notes = notes ? `${notes}\n${reviewNote}` : reviewNote
-          }
-          reviewItems.push({
-            type: 'city-from-description',
-            rowIndex: dataRowIndex + 1,
-            columnLabel:
-              descriptionColumnLabel || getColumnLabel(descriptionColumnIndex ?? 0),
-            sourceValue: descriptionSourceValue,
-            extractedCity: finalCity || detectedCity,
-            cleanedDescription: cleanDescription
-          })
-        }
-
-        newExpenses.push({
-          amount: expenseData.amount,
-          description: cleanDescription,
-          notes,
-          category_id: '',
-          expense_date: expenseData.expense_date || getCurrentDateISO(),
-          expense_time: expenseData.expense_time || null,
-          city: finalCity,
-          city_id: resolvedCityId,
-          tempId: expenseData.tempId!
-        })
-      }
-    })
-
-    stats.importedRows = newExpenses.length
-    stats.skippedRows = Math.max(stats.totalRows - stats.importedRows, 0)
-
-    return { expenses: newExpenses, stats, reviewItems }
-  }, [pastedData, hasHeaderRow, resolveCityByInput])
-
-  const appendExpensesWithStats = useCallback((result: BuildExpensesResult) => {
-    const { expenses: newExpenses, stats } = result
-
-    setExpenses(prev => [...prev, ...newExpenses])
-    setPastedData([])
-    setHasHeaderRow(false)
-
-    showToast(`Добавлено ${newExpenses.length} из ${stats.totalRows} записей`, 'success')
-
-    if (stats.autoDetectedCities > 0 || stats.detectedTimes > 0 || stats.manualTimes > 0) {
-      const details: string[] = []
-      if (stats.autoDetectedCities > 0) {
-        details.push(`автогорода: ${stats.autoDetectedCities}`)
-      }
-      if (stats.manualTimes + stats.detectedTimes > 0) {
-        details.push(`время: ${stats.manualTimes + stats.detectedTimes}`)
-      }
-      const suffix = details.length > 0 ? ` (${details.join(', ')})` : ''
-      showToast(`Пожалуйста, подтвердите автоматически заполненные поля${suffix}.`, 'info')
-    } else {
-      showToast('Проверьте импортированные данные перед сохранением.', 'info')
-    }
-  }, [showToast])
-
-  const saveImportedExpenses = useCallback(async (result: BuildExpensesResult) => {
-    const { expenses: newExpenses, stats } = result
-
-    let batchId: string | undefined = undefined;
-    if (fileName) {
-        batchId = crypto.randomUUID();
-        const fileType = fileName.split('.').pop()?.toLowerCase() || 'unknown';
-        
-        const statementResult = await createBankStatement({
-            id: batchId,
-            filename: fileName,
-            file_type: fileType,
-            total_records: newExpenses.length,
-        });
-
-        if (statementResult.error) {
-            showToast(`Ошибка создания записи о выписке: ${statementResult.error}`, 'error');
-            return false;
-        }
-    }
-
-    const expensesToCreate: CreateExpenseData[] = newExpenses.map(expense => ({
-      amount: expense.amount,
-      description: expense.description,
-      notes: expense.notes,
-      category_id: expense.category_id || undefined,
-      expense_date: expense.expense_date,
-      expense_time: expense.expense_time || null,
-      city_id: expense.city_id || undefined,
-      city_input: expense.city?.trim() || undefined,
-      input_method: 'bulk_table' as const,
-      batch_id: batchId
-    }))
-
-    const resultAction = await createBulkExpenses(expensesToCreate)
-
-    if (resultAction.error) {
-      showToast(resultAction.error, 'error')
-      return false
-    }
-
-    if (resultAction.success && resultAction.stats) {
-      const { success, failed, uncategorized, total } = resultAction.stats
-
-      let message = `Создано ${success} из ${total} расходов`
-      if (failed > 0) {
-        message += `, ${failed} с ошибками`
-      }
-      if (uncategorized > 0) {
-        message += `, ${uncategorized} без категории`
-      }
-
-      showToast(message, success > 0 ? 'success' : 'error')
-
-      if (success > 0) {
-        setPastedData([])
-        setHasHeaderRow(false)
-        setFileName('')
-
-        if (stats.autoDetectedCities > 0 || stats.detectedTimes > 0 || stats.manualTimes > 0) {
-          const details: string[] = []
-          if (stats.autoDetectedCities > 0) {
-            details.push(`автогорода: ${stats.autoDetectedCities}`)
-          }
-          if (stats.manualTimes + stats.detectedTimes > 0) {
-            details.push(`время: ${stats.manualTimes + stats.detectedTimes}`)
-          }
-          const suffix = details.length > 0 ? ` (${details.join(', ')})` : ''
-          showToast(`Автоматически заполненные поля сохранены${suffix}. Проверьте их в списке расходов.`, 'info')
-        }
-
-        if (autoRedirect) {
-          router.push('/expenses')
-        }
-      }
-
-      return success > 0
-    }
-
-    return false
-  }, [showToast, autoRedirect, router, fileName])
-
-  // Применение настроек столбцов
-  const handleColumnMappingApply = useCallback((mapping: ColumnMapping[]) => {
-    try {
-      // Сохраняем схему столбцов для будущего использования
-      saveColumnMapping(mapping)
-
-      // В режиме редактирования только сохраняем настройки
-      if (isEditingColumnMapping) {
-        showToast('Настройки столбцов сохранены', 'success')
-        return
-      }
-
-      const result = buildExpensesFromMappedData(mapping)
-
-      if (result.expenses.length > 0) {
-        if (result.reviewItems.length > 0) {
-          setReviewModalState({
-            mode: 'append',
-            result
-          })
-          showToast('Найдены автоматически выделенные поля. Подтвердите импорт.', 'info')
-        } else {
-          appendExpensesWithStats(result)
-        }
-      } else {
-        showToast('Не удалось обработать данные с текущими настройками столбцов', 'error')
-      }
-    } catch (error) {
-      console.error('Ошибка при обработке данных маппинга', error)
-      showToast('Ошибка при обработке данных', 'error')
-    }
-  }, [
-    saveColumnMapping,
-    isEditingColumnMapping,
-    showToast,
-    buildExpensesFromMappedData,
-    appendExpensesWithStats
-  ])
-
-  // Применение настроек столбцов и прямое сохранение
-  const handleColumnMappingApplyAndSave = useCallback(async (mapping: ColumnMapping[]) => {
-    try {
-      // Сохраняем схему столбцов для будущего использования
-      saveColumnMapping(mapping)
-
-      const result = buildExpensesFromMappedData(mapping)
-
-      if (result.expenses.length === 0) {
-        showToast('Не удалось обработать данные с текущими настройками столбцов', 'error')
-        return
-      }
-
-      if (result.reviewItems.length > 0) {
-        setReviewModalState({
-          mode: 'directSave',
-          result
-        })
-        showToast('Найдены автоматически выделенные поля. Подтвердите сохранение.', 'info')
-        return
-      }
-
-      await saveImportedExpenses(result)
-
-    } catch (error) {
-      showToast('Ошибка при сохранении расходов', 'error')
-    }
-  }, [saveColumnMapping, buildExpensesFromMappedData, showToast, saveImportedExpenses])
-
-  const reviewSummary = useMemo(() => {
-    if (!reviewModalState) {
-      return { cityItems: [] as CityReviewItem[] }
-    }
-
-    const cityItems = reviewModalState.result.reviewItems.filter(
-      (item): item is CityReviewItem => item.type === 'city-from-description'
-    )
-
-    return { cityItems }
-  }, [reviewModalState])
 
   const hasPendingDataset = pastedData.length > 0
 
@@ -839,25 +166,11 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
     if (!reviewModalState) {
       return
     }
-
-    if (reviewModalState.mode === 'append') {
-      showToast('Импорт отменён. При необходимости скорректируйте назначение столбцов.', 'info')
-      if (hasPendingDataset) {
-        setIsEditingColumnMapping(false)
-        setIsColumnMappingOpen(true)
-      }
-    } else {
-      showToast('Прямое сохранение отменено.', 'info')
-    }
-
     setReviewModalState(null)
-  }, [
-    reviewModalState,
-    showToast,
-    hasPendingDataset,
-    setIsEditingColumnMapping,
-    setIsColumnMappingOpen
-  ])
+    if (reviewModalState.mode === 'append' && hasPendingDataset) {
+      setIsColumnMappingOpen(true)
+    }
+  }, [hasPendingDataset, reviewModalState])
 
   const handleReviewConfirm = useCallback(async () => {
     if (!reviewModalState) {
@@ -865,348 +178,62 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
     }
 
     if (reviewModalState.mode === 'append') {
-      const resultToApply = reviewModalState.result
+      appendExpensesWithStats(reviewModalState.result)
       setReviewModalState(null)
-      appendExpensesWithStats(resultToApply)
       return
     }
 
-    const resultToSave = reviewModalState.result
-    setIsReviewProcessing(true)
-    try {
-      const success = await saveImportedExpenses(resultToSave)
-      if (success) {
-        setReviewModalState(null)
-      }
-    } finally {
-      setIsReviewProcessing(false)
+    const success = await saveImportedExpenses(reviewModalState.result)
+    if (success) {
+      setReviewModalState(null)
     }
-  }, [reviewModalState, appendExpensesWithStats, saveImportedExpenses])
+  }, [appendExpensesWithStats, reviewModalState, saveImportedExpenses])
 
-  const totalReviewCount = reviewSummary.cityItems.length
-  const cityPreview = reviewSummary.cityItems.slice(0, 6)
-  const cityOverflow = reviewSummary.cityItems.length - cityPreview.length
-  const reviewPrimaryLabel = reviewModalState?.mode === 'directSave'
-    ? (isReviewProcessing ? 'Сохранение...' : 'Подтвердить и сохранить')
-    : 'Подтвердить импорт'
+  const handleOpenColumnMapping = useCallback(() => {
+    const sampleData = savedColumnMapping && savedColumnMapping.length > 0
+      ? [savedColumnMapping.map((_, index) => `Столбец ${String.fromCharCode(65 + index)}`)]
+      : [['Столбец A', 'Столбец B', 'Столбец C', 'Столбец D']]
 
-  const processTableSelection = useCallback(
-    async (tableIndex: number, currentFileContent: string, currentFileName: string, tableInfo?: TableInfo) => {
-      setIsFileLoading(true)
+    setPastedData(sampleData)
+    setHasHeaderRow(false)
+    setIsEditingColumnMapping(true)
+    setIsColumnMappingOpen(true)
+  }, [savedColumnMapping])
 
-      // Сохраняем выбранный индекс таблицы
-      saveTableIndex(tableIndex)
-
-      const resolvedInfo =
-        tableInfo ??
-        availableTables.find(table => table.index === tableIndex) ??
-        availableTables[tableIndex]
-
-      if (resolvedInfo) {
-        setSelectedTableMeta({
-          index: resolvedInfo.index,
-          description: resolvedInfo.description,
-          rowCount: resolvedInfo.rowCount,
-          columnCount: resolvedInfo.columnCount,
-          hasHeaders: resolvedInfo.hasHeaders
-        })
-      }
-
-      try {
-        const parsed = await parseBankStatementFile(new File([currentFileContent], currentFileName), tableIndex)
-        const prepared = prepareParsedDataset(parsed)
-        const dataset = prepared.rows
-
-        if (dataset.length === 0) {
-          showToast('Выбранная таблица не содержит данных', 'error')
-          return
-        }
-
-        const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
-        if (dataRows.length === 0) {
-          showToast('Выбранная таблица содержит только заголовки', 'warning')
-          return
-        }
-
-        if (dataRows[0].length > 1) {
-          setPastedData(dataset)
-          setHasHeaderRow(prepared.hasHeader)
-          setIsEditingColumnMapping(false)
-          setIsColumnMappingOpen(true)
-          showToast(`Загружено ${dataRows.length} строк из выбранной таблицы`, 'success')
-        } else {
-          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'выбранной таблицы')
-          setHasHeaderRow(false)
-        }
-      } catch (error) {
-        showToast(error instanceof Error ? error.message : 'Ошибка обработки таблицы', 'error')
-      } finally {
-        setShowTableSelection(false)
-        setIsFileLoading(false)
-      }
+  const handleMappingApply = useCallback(
+    (mapping: ColumnMapping[]) => {
+      handleColumnMappingApply(mapping)
+      setIsColumnMappingOpen(false)
     },
-    [appendSingleColumnExpenses, availableTables, saveTableIndex, showToast]
+    [handleColumnMappingApply]
   )
 
-  // Обработка выбора таблицы из HTML файла
-  const handleTableSelection = useCallback(
-    async (tableIndex: number, tableInfo?: TableInfo) => {
-      if (!fileContent || !fileName) {
-        showToast('Сначала загрузите файл с выпиской', 'error')
-        return
-      }
-      await processTableSelection(tableIndex, fileContent, fileName, tableInfo)
+  const handleMappingApplyAndSave = useCallback(
+    (mapping: ColumnMapping[]) => {
+      handleColumnMappingApplyAndSave(mapping)
+      setIsColumnMappingOpen(false)
     },
-    [fileContent, fileName, processTableSelection, showToast]
+    [handleColumnMappingApplyAndSave]
   )
-
-
-
-  const handlePreviewTable = (tableIndex: number) => {
-    if (!fileContent) return;
-
-    try {
-      const parsedTable = parseHTML(fileContent, tableIndex);
-      const allRows = parsedTable.headers && parsedTable.headers.length > 0 
-        ? [parsedTable.headers, ...parsedTable.rows] 
-        : parsedTable.rows;
-
-      setPreviewedTable({
-        description: availableTables[tableIndex]?.description || `Таблица ${tableIndex + 1}`,
-        rows: allRows,
-      });
-      setIsPreviewModalOpen(true);
-    } catch (error) {
-      console.error("Error previewing table:", error);
-      showToast("Не удалось загрузить предпросмотр таблицы", "error");
-    }
-  };
-
-  // Загрузка из файла
-  const handleFileUpload = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
-
-    setIsFileLoading(true)
-    try {
-      const fileExtension = file.name.split('.').pop()?.toLowerCase()
-      const content = await file.text()
-
-      // Сохраняем информацию о файле
-      setFileName(file.name)
-      setFileContent(content)
-      setSelectedTableMeta(null)
-      setAvailableTables([])
-
-      // Для HTML файлов показываем выбор таблицы
-      if (fileExtension === 'html' || fileExtension === 'htm') {
-        try {
-          const analysis = analyzeHTML(content)
-
-          if (analysis.tables.length === 0) {
-            showToast('В HTML файле не найдено таблиц с данными', 'error')
-            setIsFileLoading(false)
-            return
-          }
-
-          setAvailableTables(analysis.tables)
-
-          if (analysis.tables.length === 1) {
-            // Если только одна таблица, используем её сразу
-            await processTableSelection(0, content, file.name, analysis.tables[0])
-          } else {
-            // Проверяем, есть ли сохраненный индекс таблицы и подходит ли он
-            const savedIdx = loadSavedTableIndex()
-            if (savedIdx !== null &&
-                savedIdx >= 0 &&
-                savedIdx < analysis.tables.length) {
-              // Используем сохраненную таблицу автоматически
-              await processTableSelection(savedIdx, content, file.name, analysis.tables[savedIdx])
-            } else {
-              // Показываем выбор таблицы
-              setShowTableSelection(true)
-              setIsFileLoading(false)
-            }
-          }
-        } catch (error) {
-          showToast(error instanceof Error ? error.message : 'Ошибка анализа HTML файла', 'error')
-          setIsFileLoading(false)
-        }
-      } else {
-        const parsed = await parseBankStatementFile(file)
-        const prepared = prepareParsedDataset(parsed)
-        const dataset = prepared.rows
-
-        if (dataset.length === 0) {
-          showToast('Файл пуст', 'error')
-          setIsFileLoading(false)
-          return
-        }
-
-        const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
-        if (dataRows.length === 0) {
-          showToast('В файле найдены только заголовки без данных', 'warning')
-          setIsFileLoading(false)
-          return
-        }
-
-        if (dataRows[0].length > 1) {
-          setPastedData(dataset)
-          setHasHeaderRow(prepared.hasHeader)
-          setIsEditingColumnMapping(false)
-          setIsColumnMappingOpen(true)
-          showToast(`Загружено ${dataRows.length} строк из файла`, 'success')
-        } else {
-          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'файла')
-          setHasHeaderRow(false)
-        }
-        setIsFileLoading(false)
-      }
-    } catch (error) {
-      showToast('Ошибка при загрузке файла', 'error')
-      setIsFileLoading(false)
-    } finally {
-      // Очищаем input для возможности повторной загрузки того же файла
-      if (fileInputRef.current) {
-        fileInputRef.current.value = ''
-      }
-    }
-  }, [showToast, processTableSelection, loadSavedTableIndex, appendSingleColumnExpenses])
-
-  // Прямое сохранение без предпросмотра
-  const handleDirectSave = useCallback(async () => {
-    if (expenses.length === 0) {
-      showToast('Добавьте хотя бы один расход', 'error')
-      return
-    }
-
-    if (!validateExpenses()) {
-      showToast('Исправьте ошибки в данных', 'error')
-      return
-    }
-
-    setIsSubmitting(true)
-
-    try {
-      let batchId: string | undefined = undefined;
-      if (fileName) {
-          batchId = crypto.randomUUID();
-          const fileType = fileName.split('.').pop()?.toLowerCase() || 'unknown';
-          
-          const statementResult = await createBankStatement({
-              id: batchId,
-              filename: fileName,
-              file_type: fileType,
-              total_records: expenses.length,
-          });
-
-          if (statementResult.error) {
-              showToast(`Ошибка создания записи о выписке: ${statementResult.error}`, 'error');
-              setIsSubmitting(false);
-              return;
-          }
-      }
-
-      // Преобразуем данные для отправки
-      const expensesToCreate: CreateExpenseData[] = expenses.map(expense => ({
-        amount: expense.amount,
-        description: expense.description,
-        notes: expense.notes,
-        category_id: expense.category_id || undefined,
-        expense_date: expense.expense_date,
-        expense_time: expense.expense_time || null,
-        city_id: expense.city_id || undefined,
-        city_input: expense.city?.trim() || undefined,
-        input_method: 'bulk_table' as const,
-        batch_id: batchId
-      }))
-
-      const result = await createBulkExpenses(expensesToCreate)
-
-      if (result.error) {
-        showToast(result.error, 'error')
-        return
-      }
-
-      if (result.success && result.stats) {
-        const { success, failed, uncategorized, total } = result.stats
-
-        let message = `Создано ${success} из ${total} расходов`
-        if (failed > 0) {
-          message += `, ${failed} с ошибками`
-        }
-        if (uncategorized > 0) {
-          message += `, ${uncategorized} без категории`
-        }
-
-        showToast(message, success > 0 ? 'success' : 'error')
-
-        // Очищаем форму при успехе
-        if (success > 0) {
-          setExpenses([])
-          setFileName('')
-
-          // Перенаправляем на страницу расходов только если включен автопереход
-          if (autoRedirect) {
-            router.push('/expenses')
-          }
-        }
-      }
-    } catch (error) {
-      showToast('Произошла ошибка при сохранении', 'error')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }, [expenses, validateExpenses, showToast, router, autoRedirect, fileName])
-
-  // Очистить все данные
-  const handleClear = useCallback(() => {
-    setExpenses([])
-    setValidationErrors({})
-    setSelectedTableMeta(null)
-    setAvailableTables([])
-    setFileContent(null)
-    setFileName('')
-  }, [])
-
-  const handleRequestTableReplacement = useCallback(() => {
-    if (!fileContent) {
-      showToast('Не найдено данных из файла для смены таблицы.', 'warning');
-      return;
-    }
-    setIsColumnMappingOpen(false);
-    setShowTableSelection(true);
-  }, [fileContent, showToast]);
 
   return (
     <div className="space-y-6">
-      <Card className="p-6">
-        <div className="flex flex-col sm:flex-row gap-4 mb-6">
-          <h2 className="text-xl font-semibold text-gray-900 flex-1">
-            Массовый ввод и банковские выписки
-          </h2>
-
+      <Card className="p-6 space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">Массовый ввод и банковские выписки</h2>
           <div className="flex flex-wrap items-center gap-3">
-            {/* Переключатель автоперехода */}
             <div
               className="flex items-center gap-2 cursor-pointer select-none"
-              onClick={() => setAutoRedirect(!autoRedirect)}
+              onClick={() => setAutoRedirect(prev => !prev)}
             >
               <span className="text-sm text-gray-700">Автопереход</span>
               <div className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${autoRedirect ? 'bg-blue-600' : 'bg-gray-200'}`}>
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${autoRedirect ? 'translate-x-6' : 'translate-x-1'}`} />
               </div>
             </div>
-
-            <div className="h-6 w-px bg-gray-300"></div> {/* Разделитель */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={addRow}
-            >
+            <Button variant="outline" size="sm" onClick={addRow}>
               + Добавить строку
             </Button>
-
             <Button
               variant="outline"
               size="sm"
@@ -1223,81 +250,32 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
                 '📁 Загрузить файл'
               )}
             </Button>
-
-            {isFileLoading && (
-              <div
-                className="flex items-center gap-2 text-sm text-blue-700 basis-full sm:basis-auto"
-                aria-live="polite"
-              >
-                <span className="h-3 w-3 animate-spin rounded-full border border-blue-400 border-t-transparent" />
-                <span>
-                  {fileName ? `Обрабатываем «${fileName}»...` : 'Подготавливаем данные файла...'}
-                </span>
-              </div>
-            )}
-
             {fileContent && availableTables.length > 1 && (
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setShowTableSelection(true)}
                 disabled={isFileLoading}
-                className={isFileLoading ? 'cursor-wait opacity-80' : undefined}
               >
                 📊 Выбрать таблицу
               </Button>
             )}
-
             <Button
               variant="outline"
               size="sm"
-              onClick={() => {
-                // Проверяем, есть ли сохраненная схема
-                const savedMapping = loadSavedColumnMapping()
-
-                if (savedMapping.length > 0) {
-                  // Создаем только заголовки столбцов на основе сохраненной схемы
-                  const sampleData = [
-                    savedMapping.map((_item: ColumnMapping, index: number) => `Столбец ${String.fromCharCode(65 + index)}`)
-                  ]
-                  setPastedData(sampleData)
-                } else {
-                  // Создаем стандартные заголовки столбцов
-                  const sampleData = [
-                    ['Столбец A', 'Столбец B', 'Столбец C', 'Столбец D']
-                  ]
-                  setPastedData(sampleData)
-                }
-                setHasHeaderRow(false)
-                setIsEditingColumnMapping(true)
-                setIsColumnMappingOpen(true)
-              }}
+              onClick={handleOpenColumnMapping}
               title="Настроить порядок столбцов для вставки данных"
             >
-              ⚙️ Настройка столбцов <span className={`ml-1 text-xs ${isMounted && (savedColumnMapping || savedTableIndex !== null) ? 'opacity-100' : 'opacity-0'}`}>●</span>
+              ⚙️ Настройка столбцов
+              <span className={`ml-1 text-xs ${isMounted && (savedColumnMapping || savedTableIndex !== null) ? 'opacity-100' : 'opacity-0'}`}>
+                ●
+              </span>
             </Button>
-
             {isMounted && savedTableIndex !== null && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  clearSavedTableIndex()
-                  showToast('Сохраненный выбор таблицы очищен', 'info')
-                }}
-              >
+              <Button variant="outline" size="sm" onClick={clearSavedTableIndex}>
                 ♻️ Сбросить выбор таблицы
               </Button>
             )}
-
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="*/*"
-              onChange={handleFileUpload}
-              className="hidden"
-            />
-
             {selectedTableMeta && (
               <div className="w-full rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
                 <span className="font-medium">Текущая таблица:</span> {selectedTableMeta.description}
@@ -1307,18 +285,12 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
                 </span>
               </div>
             )}
-
             {expenses.length > 0 && (
               <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleClear}
-                >
+                <div className="h-6 w-px bg-gray-300" />
+                <Button variant="outline" size="sm" onClick={handleClear}>
                   🗑️ Очистить
                 </Button>
-
-
                 <Button
                   variant="primary"
                   size="sm"
@@ -1328,7 +300,7 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
                 >
                   {isSubmitting ? (
                     <span className="flex items-center gap-2">
-                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
                       Сохранение...
                     </span>
                   ) : (
@@ -1340,29 +312,24 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
           </div>
         </div>
 
-
+        {isFileLoading && (
+          <div className="flex items-center gap-2 text-sm text-blue-700" aria-live="polite">
+            <span className="h-3 w-3 animate-spin rounded-full border border-blue-400 border-t-transparent" />
+            <span>{fileName ? `Обрабатываем «${fileName}»...` : 'Подготавливаем данные файла...'}</span>
+          </div>
+        )}
 
         {expenses.length === 0 ? (
-          <div
-            className={`relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors cursor-pointer ${isDragOver ? 'bg-blue-50 border-blue-400' : 'bg-white'}`}
+          <Dropzone
+            ref={fileInputRef}
+            isDragOver={isDragOver}
+            onClick={() => fileInputRef.current?.click()}
             onPaste={handlePaste}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
-            onClick={() => fileInputRef.current?.click()}
-            tabIndex={0}
-            role="button"
-            aria-label="Загрузить файл"
-          >
-            <div className="flex flex-col items-center gap-2 text-gray-500">
-              <svg xmlns="http://www.w3.org/2000/svg" className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <span className="mt-2 block text-sm font-semibold text-gray-900">Перетащите файлы сюда или нажмите для загрузки</span>
-              <span className="block text-xs text-gray-500">CSV, Excel, HTML или просто вставьте из буфера обмена</span>
-            </div>
-            <input ref={fileInputRef} type="file" accept="*/*" onChange={handleFileUpload} className="hidden" />
-          </div>
+            onFileChange={handleFileUpload}
+          />
         ) : (
           <BulkExpenseTable
             expenses={expenses}
@@ -1377,344 +344,53 @@ export function BulkExpenseInput({ categories }: BulkExpenseInputProps) {
           />
         )}
 
-        <div className="mt-4 p-4 bg-blue-50 rounded-lg">
-          <h3 className="font-medium text-blue-900 mb-2">Как использовать:</h3>
-          <ul className="text-sm text-blue-800 space-y-1">
-            <li>• Добавляйте строки кнопкой &quot;Добавить строку&quot;</li>
-            <li>• Копируйте данные из Excel/Google Sheets и вставляйте (Ctrl+V)</li>
-            <li>• Загружайте файлы любых форматов: CSV, HTML, XLSX, OFX и другие</li>
-            <li>• Для HTML файлов (банковские выписки) система найдет все таблицы и предложит выбрать нужную</li>
-            <li>• <strong>Выбор таблицы запоминается</strong> - при следующей загрузке будет использована та же таблица</li>
-            <li>• Используйте &quot;Настройка столбцов&quot; для изменения порядка полей</li>
-            <li>• Система автоматически определит категории по описанию</li>
-          </ul>
-        </div>
+        <HowToUse />
       </Card>
 
-      {/* Модальное окно подтверждения автоизвлечения */}
-      <Modal
-        isOpen={Boolean(reviewModalState)}
-        onClose={handleReviewCancel}
-        title="Проверка автоматически выделенных полей"
-        size="xl"
-      >
-        {reviewModalState && (
-          <div className="space-y-6">
-            <div className="bg-blue-50 border border-blue-100 rounded-lg p-4">
-              <p className="text-sm text-blue-900">
-                Система выделила дополнительные данные в {totalReviewCount}{' '}
-                {totalReviewCount === 1 ? 'строке' : 'строках'}. Проверьте результаты и подтвердите, что всё выглядит корректно.
-              </p>
-            </div>
+      <ReviewModal
+        state={reviewModalState}
+        isProcessing={isReviewProcessing}
+        onConfirm={handleReviewConfirm}
+        onCancel={handleReviewCancel}
+      />
 
-            <div className="flex flex-wrap gap-3">
-              {reviewSummary.cityItems.length > 0 && (
-                <span className="inline-flex items-center gap-2 rounded-full bg-blue-100 text-blue-800 px-3 py-1 text-sm">
-                  📍 Города из описания: {reviewSummary.cityItems.length}
-                </span>
-              )}
-            </div>
-
-            {reviewSummary.cityItems.length > 0 && (
-              <div className="space-y-3">
-                <h4 className="font-medium text-gray-900">Города, извлечённые из описания</h4>
-                <div className="overflow-hidden rounded-lg border border-gray-200">
-                  <div className="overflow-x-auto">
-                    <table className="min-w-full text-sm">
-                      <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
-                        <tr>
-                          <th className="px-3 py-2 text-left">Строка</th>
-                          <th className="px-3 py-2 text-left">Столбец</th>
-                          <th className="px-3 py-2 text-left">Исходное значение</th>
-                          <th className="px-3 py-2 text-left">Описание после очистки</th>
-                          <th className="px-3 py-2 text-left">Автоопределённый город</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gray-200">
-                        {cityPreview.map((item, index) => (
-                          <tr key={`city-${index}-${item.rowIndex}`} className="bg-white">
-                            <td className="px-3 py-2 align-top text-gray-500">{item.rowIndex}</td>
-                            <td className="px-3 py-2 align-top text-gray-700">{item.columnLabel}</td>
-                            <td className="px-3 py-2 align-top text-gray-900 whitespace-pre-wrap break-words">
-                              {item.sourceValue || '—'}
-                            </td>
-                            <td className="px-3 py-2 align-top text-gray-900 whitespace-pre-wrap break-words">
-                              {item.cleanedDescription || '—'}
-                            </td>
-                            <td className="px-3 py-2 align-top text-blue-700 font-semibold">
-                              {item.extractedCity}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                  {cityOverflow > 0 && (
-                    <div className="px-3 py-2 text-xs text-gray-500 bg-gray-50">
-                      и ещё {cityOverflow} {cityOverflow === 1 ? 'строка' : 'строк'} с автоопределением города
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-
-            <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-xs text-gray-500">
-                Подтверждение применит назначенные столбцы и перенесёт данные в таблицу расходов.
-              </p>
-              <div className="flex gap-3 justify-end">
-                <Button
-                  variant="outline"
-                  onClick={handleReviewCancel}
-                  disabled={isReviewProcessing}
-                >
-                  Вернуться
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={handleReviewConfirm}
-                  disabled={isReviewProcessing}
-                >
-                  {reviewModalState.mode === 'directSave' && isReviewProcessing ? (
-                    <span className="flex items-center gap-2">
-                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                      {reviewPrimaryLabel}
-                    </span>
-                  ) : (
-                    reviewPrimaryLabel
-                  )}
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </Modal>
-
-      {/* Модальное окно выбора таблицы */}
-      <Modal
+      <TableSelectionModal
         isOpen={showTableSelection}
+        tables={availableTables}
+        savedIndex={savedTableIndex}
+        isLoading={isFileLoading}
+        onSelect={handleTableSelection}
         onClose={() => {
           setShowTableSelection(false)
-          setIsFileLoading(false)
           if (!selectedTableMeta) {
-            setAvailableTables([])
-            setFileContent(null)
-            setFileName('')
+            handleFileStateReset()
           }
         }}
-        title="Выбор таблицы"
-        size="xl"
-      >
-        {availableTables.length > 0 && (
-          <div className="space-y-4">
-            <div className="text-sm text-gray-600">
-              Найдено {availableTables.length} таблиц. Выберите таблицу для импорта:
-            </div>
+        onPreview={handlePreviewTable}
+      />
 
-
-
-            <div className="space-y-3 max-h-96 overflow-y-auto">
-              {availableTables.map((table, index) => (
-                <div
-                  key={index}
-                  className={`p-4 border rounded-lg transition-colors ${
-                    (savedTableIndex !== null && savedTableIndex === index) || (savedTableIndex === null && index === 0)
-                      ? 'border-blue-500 bg-blue-50'
-                      : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
-                  } ${isFileLoading ? 'cursor-wait opacity-60' : 'cursor-pointer'}`}
-                  tabIndex={isFileLoading ? -1 : 0}
-                  aria-disabled={isFileLoading}
-                  onClick={() => {
-                    handleTableSelection(index)
-                  }}
-                  onKeyDown={event => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      handleTableSelection(index)
-                    }
-                  }}
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex-1">
-                      <h3 className="font-medium text-gray-900">
-                        {table.description}
-                      </h3>
-                      <p className="text-sm text-gray-500">
-                        {table.rowCount} строк, {table.columnCount} столбцов
-                      </p>
-                      <p className="mt-1 text-xs text-gray-500">
-                        {table.hasHeaders ? 'Содержит строку заголовков' : 'Без отдельной строки заголовков'}
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      {savedTableIndex === index && (
-                        <div className="text-blue-600 text-sm font-medium">
-                          ✓ Ранее
-                        </div>
-                      )}
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handlePreviewTable(index);
-                        }}
-                      >
-                        Предпросмотр
-                      </Button>
-                    </div>
-                  </div>
-
-                  {table.preview.length > 0 && (
-                    <div className="mt-3 overflow-hidden rounded-md border bg-white">
-                      <div className="overflow-x-auto">
-                        <table className="min-w-full divide-y divide-gray-200 text-xs">
-                          <tbody className="divide-y divide-gray-100">
-                            {table.preview.map((previewRow, previewIndex) => (
-                              <tr key={previewIndex} className="bg-white">
-                                {previewRow.map((cell, cellIndex) => (
-                                  <td
-                                    key={cellIndex}
-                                    className={`px-3 py-2 whitespace-nowrap ${
-                                      previewIndex === 0 ? 'font-medium text-gray-900' : 'text-gray-600'
-                                    }`}
-                                  >
-                                    {cell || '—'}
-                                  </td>
-                                ))}
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-            
-            <div className="flex justify-end space-x-3 pt-4 border-t">
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setShowTableSelection(false)
-                  setAvailableTables([])
-                  setFileContent(null)
-                  setFileName('')
-                }}
-              >
-                Отмена
-              </Button>
-            </div>
-          </div>
-        )}
-      </Modal>
-
-      {/* Модальное окно предпросмотра таблицы */}
-      <Modal
+      <TablePreviewModal
         isOpen={isPreviewModalOpen}
+        table={previewedTable}
         onClose={() => setIsPreviewModalOpen(false)}
-        title={`Предпросмотр: ${previewedTable?.description || ''}`}
-        size="xl"
-      >
-        {previewedTable && (
-          <div className="max-h-[70vh] overflow-auto border border-gray-200 rounded-lg">
-            <table className="min-w-full text-xs border-collapse">
-              <thead className="sticky top-0 bg-gray-100 z-10">
-                {previewedTable.rows[0] && (
-                  <tr>
-                    {previewedTable.rows[0].map((cell, cellIndex) => (
-                      <th key={cellIndex} className="border-b border-gray-300 p-2 text-left font-semibold text-gray-700">{cell}</th>
-                    ))}
-                  </tr>
-                )}
-              </thead>
-              <tbody>
-                {previewedTable.rows.slice(1).map((row, rowIndex) => (
-                  <tr key={rowIndex} className="even:bg-gray-50">
-                    {row.map((cell, cellIndex) => (
-                      <td key={cellIndex} className="border-b border-gray-200 p-2">{cell}</td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Modal>
+      />
 
-      {/* Модальное окно настройки столбцов */}
       <ColumnMappingModal
         isOpen={isColumnMappingOpen}
         onClose={() => {
           setIsColumnMappingOpen(false)
-          setPastedData([])
-          setHasHeaderRow(false)
-          setIsEditingColumnMapping(false)
+          if (!isEditingColumnMapping) {
+            handleDatasetClear()
+          }
         }}
-        onApply={handleColumnMappingApply}
-        onApplyAndSave={handleColumnMappingApplyAndSave}
+        onApply={handleMappingApply}
+        onApplyAndSave={isEditingColumnMapping ? undefined : handleMappingApplyAndSave}
         sampleData={pastedData}
         savedMapping={savedColumnMapping}
         isEditingMode={isEditingColumnMapping}
         tableDescription={selectedTableMeta?.description}
-        onReplaceTable={handleRequestTableReplacement}
+        onReplaceTable={fileContent ? () => setShowTableSelection(true) : undefined}
       />
     </div>
   )
-}
-
-const COLUMN_MAPPING_FIELDS: ColumnMappingField[] = [
-  'amount',
-  'description',
-  'city',
-  'expense_date',
-  'expense_time',
-  'notes'
-]
-
-const COLUMN_MAPPING_FIELD_SET = new Set<ColumnMappingField>(COLUMN_MAPPING_FIELDS)
-
-function isColumnMappingField(value: unknown): value is ColumnMappingField {
-  return typeof value === 'string' && COLUMN_MAPPING_FIELD_SET.has(value as ColumnMappingField)
-}
-
-function normalizeColumnMapping(raw: unknown): ColumnMapping[] {
-  if (!Array.isArray(raw)) {
-    return []
-  }
-
-  return raw.map((item, index) => {
-    const candidate = item as Partial<ColumnMapping> & { targetField?: unknown }
-
-    const directTargets = Array.isArray(candidate?.targetFields)
-      ? candidate.targetFields.filter(isColumnMappingField)
-      : []
-
-    const legacyTarget = isColumnMappingField(candidate?.targetField)
-      ? [candidate.targetField]
-      : []
-
-    const combinedTargets = [...directTargets, ...legacyTarget]
-    const uniqueTargets = Array.from(new Set(combinedTargets))
-
-    const normalizedTargets = uniqueTargets.filter(isColumnMappingField)
-
-    const normalizedEnabled = typeof candidate?.enabled === 'boolean'
-      ? candidate.enabled && normalizedTargets.length > 0
-      : normalizedTargets.length > 0
-
-    return {
-      sourceIndex: typeof candidate?.sourceIndex === 'number' ? candidate.sourceIndex : index,
-      targetFields: normalizedEnabled ? normalizedTargets : [],
-      enabled: normalizedEnabled && normalizedTargets.length > 0,
-      preview: typeof candidate?.preview === 'string' ? candidate.preview : '',
-      hidden: Boolean(candidate?.hidden)
-    }
-  })
-}
-
-function sanitizeColumnMapping(mapping: ColumnMapping[]): ColumnMapping[] {
-  return normalizeColumnMapping(mapping)
 }

--- a/src/components/expense-input/bulk-input/ColumnMappingModal.tsx
+++ b/src/components/expense-input/bulk-input/ColumnMappingModal.tsx
@@ -1,102 +1,80 @@
 'use client'
 
-import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react'
-import { createPortal } from 'react-dom'
+import { useEffect, useMemo, useState } from 'react'
 import { Modal } from '@/components/ui/Modal'
 import { Button } from '@/components/ui/Button'
 import type { ColumnMapping, ColumnMappingField } from '@/types'
-
-// Компонент подсказки
-function Tooltip({ children, content }: { children: React.ReactNode; content: string }) {
-  return (
-    <div className="relative group">
-      {children}
-      {/* Tooltip справа от элемента */}
-      <div className="absolute left-full top-1/2 transform -translate-y-1/2 ml-2 px-4 py-3 bg-gray-900 text-white text-sm rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-[10000] break-words shadow-lg" style={{maxWidth: '400px', width: 'max-content', minWidth: '200px'}}>
-        {content}
-        {/* Стрелка слева */}
-        <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-gray-900"></div>
-      </div>
-    </div>
-  )
-}
-
-// ColumnMapping импортирован из @/types
-
-interface FieldAssignment {
-  field: ColumnMappingField
-  assignedColumn: number | null
-  required: boolean
-}
+import { getColumnLabel } from './utils/columnMapping'
 
 interface ColumnMappingModalProps {
   isOpen: boolean
   onClose: () => void
   onApply: (mapping: ColumnMapping[]) => void
-  onApplyAndSave?: (mapping: ColumnMapping[]) => void // Новый проп для прямого сохранения
-  sampleData: string[][] // Первые несколько строк для предпросмотра
-  savedMapping?: ColumnMapping[] | null // Сохраненная схема столбцов
-  isEditingMode?: boolean // Режим редактирования сохраненной схемы
+  onApplyAndSave?: (mapping: ColumnMapping[]) => void
+  sampleData: string[][]
+  savedMapping?: ColumnMapping[] | null
+  isEditingMode?: boolean
   tableDescription?: string | null
   onReplaceTable?: () => void
 }
 
-const FIELD_ICONS: Record<ColumnMappingField, string> = {
-  amount: '💰',
-  description: '📝',
-  city: '📍',
-  expense_date: '📅',
-  expense_time: '⏰',
-  notes: '📋'
+interface ColumnConfig {
+  sourceIndex: number
+  label: string
+  preview: string[]
+  targetFields: ColumnMappingField[]
+  hidden: boolean
 }
 
-const FIELD_LABELS: Record<ColumnMappingField, string> = {
-  amount: 'Сумма',
-  description: 'Описание',
-  city: 'Город',
-  expense_date: 'Дата',
-  expense_time: 'Время',
-  notes: 'Примечания'
+const FIELD_OPTIONS: Array<{ value: ColumnMappingField; label: string; required?: boolean }> = [
+  { value: 'amount', label: 'Сумма', required: true },
+  { value: 'description', label: 'Описание', required: true },
+  { value: 'city', label: 'Город' },
+  { value: 'expense_date', label: 'Дата' },
+  { value: 'expense_time', label: 'Время' },
+  { value: 'notes', label: 'Примечания' }
+]
+
+const REQUIRED_FIELDS = FIELD_OPTIONS.filter(option => option.required).map(option => option.value)
+
+function buildInitialConfig(sampleData: string[][], savedMapping?: ColumnMapping[] | null): ColumnConfig[] {
+  const columnCount = Math.max(0, ...sampleData.map(row => row.length))
+  const headerRow = sampleData[0] ?? []
+  const previewRows = sampleData.slice(0, 4)
+
+  return Array.from({ length: columnCount }, (_, index) => {
+    const saved = savedMapping?.[index]
+    const preview = previewRows.map(row => row[index] ?? '')
+    const label = getColumnLabel(index, headerRow)
+
+    const targetFields = saved?.targetFields && saved.targetFields.length > 0
+      ? saved.targetFields.filter((value): value is ColumnMappingField => FIELD_OPTIONS.some(option => option.value === value))
+      : []
+
+    return {
+      sourceIndex: index,
+      label,
+      preview,
+      targetFields,
+      hidden: Boolean(saved?.hidden)
+    }
+  })
 }
 
-const FIELD_COLORS: Record<ColumnMappingField, string> = {
-  amount: 'bg-green-100 border-green-300 text-green-800',
-  description: 'bg-blue-100 border-blue-300 text-blue-800',
-  city: 'bg-indigo-100 border-indigo-300 text-indigo-800',
-  expense_date: 'bg-purple-100 border-purple-300 text-purple-800',
-  expense_time: 'bg-teal-100 border-teal-300 text-teal-800',
-  notes: 'bg-yellow-100 border-yellow-300 text-yellow-800'
+function toColumnMapping(config: ColumnConfig[]): ColumnMapping[] {
+  return config.map(column => ({
+    sourceIndex: column.sourceIndex,
+    targetFields: column.hidden ? [] : column.targetFields,
+    enabled: !column.hidden && column.targetFields.length > 0,
+    preview: column.preview.join(' | ').slice(0, 80),
+    hidden: column.hidden
+  }))
 }
 
-const COLUMN_FIELD_OPTIONS: Array<{ field: ColumnMappingField; label: string; icon: string }> = (
-  Object.keys(FIELD_LABELS) as ColumnMappingField[]
-).map(field => ({
-  field,
-  label: FIELD_LABELS[field],
-  icon: FIELD_ICONS[field]
-}))
-
-const COLUMN_FIELD_SET = new Set<ColumnMappingField>(COLUMN_FIELD_OPTIONS.map(option => option.field))
-
-function isColumnMappingField(value: unknown): value is ColumnMappingField {
-  return typeof value === 'string' && COLUMN_FIELD_SET.has(value as ColumnMappingField)
-}
-
-function createDefaultFieldAssignments(): FieldAssignment[] {
-  return [
-    { field: 'amount', assignedColumn: null, required: true },
-    { field: 'description', assignedColumn: null, required: true },
-    { field: 'city', assignedColumn: null, required: false },
-    { field: 'expense_date', assignedColumn: null, required: false },
-    { field: 'expense_time', assignedColumn: null, required: false },
-    { field: 'notes', assignedColumn: null, required: false }
-  ]
-}
-
-export function ColumnMappingModal({ 
-  isOpen, 
-  onClose, 
-  onApply, 
+export function ColumnMappingModal({
+  isOpen,
+  onClose,
+  onApply,
   onApplyAndSave,
   sampleData,
   savedMapping,
@@ -104,793 +82,186 @@ export function ColumnMappingModal({
   tableDescription,
   onReplaceTable
 }: ColumnMappingModalProps) {
-  // Инициализируем порядок столбцов (только индексы)
-  const [columnOrder, setColumnOrder] = useState<number[]>([])
+  const [config, setConfig] = useState<ColumnConfig[]>([])
 
-  // Инициализируем назначения полей
-  const [fieldAssignments, setFieldAssignments] = useState<FieldAssignment[]>([])
-  const [openColumnPicker, setOpenColumnPicker] = useState<number | null>(null)
-  const [hiddenColumns, setHiddenColumns] = useState<Set<number>>(() => new Set())
-  const [isHiddernColumnsVisible, setIsHiddernColumnsVisible] = useState(true)
-  const [pickerPosition, setPickerPosition] = useState<{
-    top: number
-    left: number
-    width: number
-  } | null>(null)
-  const columnPickerRefs = useRef<Record<number, HTMLDivElement | null>>({})
-  const dropdownContainerRef = useRef<HTMLDivElement | null>(null)
-
-  // Обновляем состояние при изменении sampleData
   useEffect(() => {
-    if (sampleData.length === 0) {
-      setColumnOrder([])
-      setFieldAssignments([])
-      setHiddenColumns(new Set())
-      return
+    if (isOpen) {
+      setConfig(buildInitialConfig(sampleData, savedMapping))
     }
+  }, [isOpen, sampleData, savedMapping])
 
-    const columnCount = Math.max(...sampleData.map(row => row.length))
-
-    const defaultOrder = Array.from({ length: columnCount }, (_, index) => index)
-    setColumnOrder(defaultOrder)
-
-    const baseAssignments = createDefaultFieldAssignments()
-    const nextHiddenColumns = new Set<number>()
-
-    if (savedMapping && savedMapping.length === columnCount) {
-      savedMapping.forEach((column, index) => {
-        const originalIndex = defaultOrder[index]
-        if (column?.hidden) {
-          nextHiddenColumns.add(originalIndex)
-          return
-        }
-
-        const targets = Array.isArray(column.targetFields)
-          ? column.targetFields.filter(isColumnMappingField)
-          : []
-
-        targets.forEach(targetField => {
-          const assignment = baseAssignments.find(item => item.field === targetField)
-          if (assignment) {
-            assignment.assignedColumn = originalIndex
-          }
-        })
+  const selectedFields = useMemo(() => {
+    const map = new Map<ColumnMappingField, number>()
+    config.forEach(column => {
+      if (column.hidden) return
+      column.targetFields.forEach(field => {
+        map.set(field, (map.get(field) ?? 0) + 1)
       })
-    }
-
-    setFieldAssignments(baseAssignments)
-    setHiddenColumns(nextHiddenColumns)
-  }, [sampleData, savedMapping])
-
-  useEffect(() => {
-    if (!isOpen) {
-      setOpenColumnPicker(null)
-    }
-  }, [isOpen])
-
-  useEffect(() => {
-    setOpenColumnPicker(null)
-  }, [columnOrder])
-
-  useEffect(() => {
-    if (openColumnPicker !== null && hiddenColumns.has(openColumnPicker)) {
-      setOpenColumnPicker(null)
-    }
-  }, [hiddenColumns, openColumnPicker])
-
-  const updatePickerPosition = useCallback(() => {
-    if (openColumnPicker === null) {
-      setPickerPosition(null)
-      return
-    }
-
-    const anchor = columnPickerRefs.current[openColumnPicker]
-    if (!anchor) {
-      setPickerPosition(null)
-      return
-    }
-
-    const rect = anchor.getBoundingClientRect()
-    const viewportWidth = typeof window !== 'undefined'
-      ? window.innerWidth || document.documentElement.clientWidth || rect.width
-      : rect.width
-    const dropdownWidth = Math.max(rect.width, 240)
-    const maxLeft = Math.max(viewportWidth - dropdownWidth - 8, 8)
-    const left = Math.min(Math.max(rect.left, 8), maxLeft)
-
-    setPickerPosition({
-      top: Math.max(rect.bottom + 4, 8),
-      left,
-      width: dropdownWidth
     })
-  }, [openColumnPicker])
+    return map
+  }, [config])
 
-  useLayoutEffect(() => {
-    if (openColumnPicker === null) {
-      setPickerPosition(null)
-      return
-    }
+  const missingRequired = REQUIRED_FIELDS.filter(field => (selectedFields.get(field) ?? 0) === 0)
 
-    updatePickerPosition()
-
-    const handleScroll = () => updatePickerPosition()
-    window.addEventListener('scroll', handleScroll, true)
-    window.addEventListener('resize', handleScroll)
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll, true)
-      window.removeEventListener('resize', handleScroll)
-    }
-  }, [openColumnPicker, updatePickerPosition])
-
-  useEffect(() => {
-    if (openColumnPicker === null) {
-      return
-    }
-
-    const handleClickOutside = (event: MouseEvent) => {
-      const container = columnPickerRefs.current[openColumnPicker]
-      const dropdown = dropdownContainerRef.current
-      const target = event.target as Node
-      if (container && container.contains(target)) {
-        return
-      }
-      if (dropdown && dropdown.contains(target)) {
-        return
-      }
-      if (container && !container.contains(target)) {
-        setOpenColumnPicker(null)
-      }
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setOpenColumnPicker(null)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [openColumnPicker])
-
-  // Назначение поля на столбец с предотвращением дублирования
-  const toggleFieldForColumn = useCallback((field: ColumnMappingField, columnIndex: number) => {
-    setFieldAssignments(prev =>
-      prev.map(assignment => {
-        if (assignment.field !== field) {
-          return assignment
+  const handleToggleField = (index: number, field: ColumnMappingField) => {
+    setConfig(prev =>
+      prev.map(column => {
+        if (column.sourceIndex !== index) {
+          return column
         }
-
-        if (assignment.assignedColumn === columnIndex) {
-          return { ...assignment, assignedColumn: null }
+        const exists = column.targetFields.includes(field)
+        return {
+          ...column,
+          targetFields: exists
+            ? column.targetFields.filter(item => item !== field)
+            : [...column.targetFields, field]
         }
-
-        return { ...assignment, assignedColumn: columnIndex }
       })
     )
-  }, [])
+  }
 
-  const toggleColumnHidden = useCallback((columnIndex: number) => {
-    setHiddenColumns(prev => {
-      const next = new Set(prev)
-      if (next.has(columnIndex)) {
-        next.delete(columnIndex)
-      } else {
-        next.add(columnIndex)
-      }
-      return next
-    })
-
-    setFieldAssignments(prev =>
-      prev.map(assignment =>
-        assignment.assignedColumn === columnIndex
-          ? { ...assignment, assignedColumn: null }
-          : assignment
+  const handleToggleHidden = (index: number) => {
+    setConfig(prev =>
+      prev.map(column =>
+        column.sourceIndex === index
+          ? { ...column, hidden: !column.hidden }
+          : column
       )
     )
+  }
 
-    setOpenColumnPicker(null)
-  }, [])
-
-  const getAssignedFields = useCallback(
-    (columnIndex: number): ColumnMappingField[] =>
-      fieldAssignments.filter(assignment => assignment.assignedColumn === columnIndex).map(assignment => assignment.field),
-    [fieldAssignments]
-  )
-
-  const visibleColumnOrder = useMemo(
-    () => columnOrder.filter(index => !hiddenColumns.has(index)),
-    [columnOrder, hiddenColumns]
-  )
-
-  const hiddenColumnOrder = useMemo(
-    () => columnOrder.filter(index => hiddenColumns.has(index)),
-    [columnOrder, hiddenColumns]
-  )
-
-  const getColumnDisplayLabel = useCallback(
-    (originalIndex: number) => {
-      const displayIndex = columnOrder.indexOf(originalIndex)
-      if (displayIndex === -1) {
-        return `Столбец ${originalIndex + 1}`
-      }
-
-      if (displayIndex >= 0 && displayIndex < 26) {
-        return `Столбец ${String.fromCharCode(65 + displayIndex)}`
-      }
-
-      return `Столбец ${displayIndex + 1}`
-    },
-    [columnOrder]
-  )
-
-  // Создание маппинга из текущих настроек
-  const createMapping = useCallback(() => {
-    const mapping: ColumnMapping[] = columnOrder.map((originalIndex, newIndex) => ({
-      sourceIndex: newIndex,
-      targetFields: [],
-      enabled: false,
-      preview: sampleData[0]?.[originalIndex] || '',
-      hidden: hiddenColumns.has(originalIndex)
-    }))
-
-    // Назначаем поля
-    fieldAssignments.forEach(assignment => {
-      if (assignment.assignedColumn !== null && !hiddenColumns.has(assignment.assignedColumn)) {
-        const orderIndex = columnOrder.indexOf(assignment.assignedColumn)
-        if (orderIndex !== -1) {
-          const targets = mapping[orderIndex].targetFields
-          if (!targets.includes(assignment.field)) {
-            targets.push(assignment.field)
-          }
-          mapping[orderIndex].enabled = true
-        }
-      }
-    })
-
-    return mapping
-  }, [columnOrder, fieldAssignments, sampleData, hiddenColumns])
-
-  // Применение настроек для редактирования
-  const handleApply = useCallback(() => {
-    // В режиме редактирования не требуем обязательные поля
-    if (!isEditingMode) {
-      // Проверяем обязательные поля только при обработке данных
-      const amountField = fieldAssignments.find(f => f.field === 'amount')
-      const descriptionField = fieldAssignments.find(f => f.field === 'description')
-      
-      if (!amountField?.assignedColumn || !descriptionField?.assignedColumn) {
-        // В обычном режиме требуем обязательные поля
-        return
-      }
-    }
-
-    const mapping = createMapping()
-    onApply(mapping)
-    onClose()
-  }, [createMapping, onApply, onClose, isEditingMode, fieldAssignments])
-
-  // Применение и прямое сохранение
-  const handleApplyAndSave = useCallback(() => {
-    // Проверяем обязательные поля
-    const amountField = fieldAssignments.find(f => f.field === 'amount')
-    const descriptionField = fieldAssignments.find(f => f.field === 'description')
-
-    if (!amountField?.assignedColumn || !descriptionField?.assignedColumn) {
-      return
-    }
-
-    if (onApplyAndSave) {
-      const confirmed = window.confirm('Сохранить все расходы с текущим назначением столбцов? Пожалуйста, убедитесь, что данные верны.')
-      if (!confirmed) {
-        return
-      }
-    }
-
-    const mapping = createMapping()
-    if (onApplyAndSave) {
+  const handleApply = (mode: 'apply' | 'applyAndSave') => {
+    const mapping = toColumnMapping(config)
+    if (mode === 'applyAndSave' && onApplyAndSave) {
       onApplyAndSave(mapping)
+    } else {
+      onApply(mapping)
     }
-    onClose()
-  }, [createMapping, onApplyAndSave, onClose, fieldAssignments])
-
-  // Вычисляем предпросмотр данных в реальном времени
-  const previewData = useMemo(() => {
-    if (sampleData.length === 0) return []
-
-    const amountField = fieldAssignments.find(f => f.field === 'amount')
-    const descriptionField = fieldAssignments.find(f => f.field === 'description')
-    const cityField = fieldAssignments.find(f => f.field === 'city')
-    const dateField = fieldAssignments.find(f => f.field === 'expense_date')
-    const timeField = fieldAssignments.find(f => f.field === 'expense_time')
-    const notesField = fieldAssignments.find(f => f.field === 'notes')
-
-    // В режиме редактирования не требуем обязательные поля для предпросмотра
-    if (!isEditingMode && (amountField?.assignedColumn === null || amountField?.assignedColumn === undefined ||
-        descriptionField?.assignedColumn === null || descriptionField?.assignedColumn === undefined)) {
-      return []
-    }
-
-    // Создаем переупорядоченные данные согласно columnOrder
-    const reorderedData = sampleData.map(row => {
-      const reorderedRow: string[] = []
-      columnOrder.forEach((originalIndex, newIndex) => {
-        reorderedRow[newIndex] = row[originalIndex] || ''
-      })
-      return reorderedRow
-    })
-
-    // Теперь используем новые индексы для получения данных
-    return reorderedData.map(row => ({
-      amount: amountField && amountField.assignedColumn !== null && amountField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(amountField.assignedColumn)] || '' : '',
-      description: descriptionField && descriptionField.assignedColumn !== null && descriptionField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(descriptionField.assignedColumn)] || '' : '',
-      city: cityField && cityField.assignedColumn !== null && cityField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(cityField.assignedColumn)] || '' : '',
-      expense_date: dateField && dateField.assignedColumn !== null && dateField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(dateField.assignedColumn)] || '' : '',
-      expense_time: timeField && timeField.assignedColumn !== null && timeField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(timeField.assignedColumn)] || '' : '',
-      notes: notesField && notesField.assignedColumn !== null && notesField.assignedColumn !== undefined ?
-        row[columnOrder.indexOf(notesField.assignedColumn)] || '' : ''
-    }))
-  }, [sampleData, fieldAssignments, columnOrder, isEditingMode])
-
-  // Сброс к значениям по умолчанию
-  const handleReset = useCallback(() => {
-    if (sampleData.length === 0) return
-
-    const columnCount = Math.max(...sampleData.map(row => row.length))
-
-    setColumnOrder(Array.from({ length: columnCount }, (_, index) => index))
-    setFieldAssignments(createDefaultFieldAssignments())
-    setHiddenColumns(new Set())
-  }, [sampleData])
-
-  if (sampleData.length === 0) {
-    return (
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-        title="Настройка столбцов"
-        size="lg"
-      >
-        <div className="text-center py-8">
-          <div className="text-gray-500">
-            <p className="text-lg mb-2">Нет данных для настройки</p>
-            <p className="text-sm">Сначала вставьте или загрузите данные</p>
-          </div>
-        </div>
-      </Modal>
-    )
   }
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title={
-        isEditingMode 
-          ? "Редактирование сохраненной схемы столбцов" 
-          : savedMapping && savedMapping.length === columnOrder.length 
-            ? "Настройка столбцов (применена сохраненная схема)" 
-            : "Настройка столбцов"
-      }
-      size="lg"
+      title="Настройка соответствия столбцов"
+      size="xl"
     >
       <div className="space-y-6">
-        {/* Информация о режиме редактирования */}
-        {isEditingMode && (
-          <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-              <span className="text-sm text-blue-800 font-medium">
-                Режим редактирования сохраненной схемы
-              </span>
-            </div>
-            <p className="text-xs text-blue-700 mt-1">
-              Изменения будут сохранены и применены к будущим массовым вводам
-            </p>
+        {tableDescription && (
+          <div className="flex items-center justify-between rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+            <span className="font-medium">Таблица: {tableDescription}</span>
+            {onReplaceTable && (
+              <Button variant="ghost" size="sm" onClick={onReplaceTable}>
+                Сменить таблицу
+              </Button>
+            )}
           </div>
         )}
 
-        {/* Таблица с данными и кликабельными заголовками */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between gap-4 mb-2">
-            <div className="flex items-center gap-2">
-              <h3 className="font-medium text-gray-900">Ваши данные</h3>
-              <Tooltip content="Кликните на заголовок столбца чтобы назначить ему поле">
-                <div className="w-4 h-4 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs cursor-help">
-                  ?
-                </div>
-              </Tooltip>
-            </div>
-            {tableDescription && onReplaceTable && !isEditingMode && (
-              <div className="flex items-center gap-2 text-sm">
-                <span>📝</span>
-                <span className="font-semibold text-gray-700" title={tableDescription}>
-                  {tableDescription}
-                </span>
-                <Button variant="primary" size="sm" onClick={onReplaceTable}>
-                  Заменить
-                </Button>
-              </div>
-            )}
+        {missingRequired.length > 0 && (
+          <div className="rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+            Назначьте обязательные поля:{' '}
+            {missingRequired
+              .map(field => FIELD_OPTIONS.find(option => option.value === field)?.label)
+              .filter((label): label is string => Boolean(label))
+              .join(', ')}
           </div>
+        )}
 
-          <p className="mb-3 text-xs text-gray-500">
-            Можно выбрать несколько полей для одного столбца — например, одновременно отметить дату и время или описание и город.
-          </p>
-
-          <div className="bg-white border rounded-lg overflow-hidden mb-4">
-            {visibleColumnOrder.length > 0 ? (
-              <div className="overflow-x-auto">
-                <table className="text-sm" style={{ width: 'auto', minWidth: '100%' }}>
-                  <thead className="bg-gray-50 border-b">
-                    <tr>
-                      {visibleColumnOrder.map(originalIndex => {
-                        const assignedFields = getAssignedFields(originalIndex)
-                        const columnLabel = getColumnDisplayLabel(originalIndex)
-                        const isOpen = openColumnPicker === originalIndex
-
+        <div className="overflow-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Столбец
+                </th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Предпросмотр
+                </th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Поля
+                </th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Видимость
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {config.map(column => (
+                <tr key={column.sourceIndex} className={column.hidden ? 'bg-gray-50 text-gray-400' : undefined}>
+                  <td className="px-3 py-3 align-top font-medium text-gray-900">
+                    {column.label}
+                  </td>
+                  <td className="px-3 py-3 align-top text-xs text-gray-600">
+                    <div className="space-y-1 whitespace-pre-wrap break-words">
+                      {column.preview.length > 0
+                        ? column.preview.map((value, index) => (
+                            <div key={index}>{value || '—'}</div>
+                          ))
+                        : 'Нет данных'}
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <div className="flex flex-wrap gap-2">
+                      {FIELD_OPTIONS.map(option => {
+                        const checked = column.targetFields.includes(option.value)
+                        const disabled = column.hidden
                         return (
-                          <th key={originalIndex} className="p-2 align-top">
-                            <div
-                              className="flex flex-col items-center gap-2"
-                              ref={node => {
-                                if (node) {
-                                  columnPickerRefs.current[originalIndex] = node
-                                } else {
-                                  delete columnPickerRefs.current[originalIndex]
-                                }
-                              }}
-                            >
-                              <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                                {columnLabel}
-                              </div>
-                              <div className="w-full max-w-[240px]">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setOpenColumnPicker(prev =>
-                                      prev === originalIndex ? null : originalIndex
-                                    )
-                                  }
-                                  aria-expanded={isOpen}
-                                  className={`flex w-full items-center justify-between rounded-md border px-3 py-1.5 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
-                                    assignedFields.length > 0
-                                      ? 'border-gray-300 bg-white text-gray-700 hover:border-blue-300 hover:text-blue-700'
-                                      : 'border-dashed border-gray-300 bg-white text-gray-400 hover:border-blue-300 hover:text-blue-600'
-                                  }`}
-                                >
-                                  <span>
-                                    {assignedFields.length > 0
-                                      ? 'Изменить выбор'
-                                      : 'Выбрать поля'}
-                                  </span>
-                                  <span
-                                    className={`ml-2 text-gray-400 transition-transform ${
-                                      isOpen ? 'rotate-180' : ''
-                                    }`}
-                                    aria-hidden
-                                  >
-                                    ▾
-                                  </span>
-                                </button>
-                              </div>
-                              {isOpen && pickerPosition && typeof window !== 'undefined'
-                                ? createPortal(
-                                    (
-                                      <div
-                                        ref={node => {
-                                          dropdownContainerRef.current = node
-                                        }}
-                                        className="z-[2000] rounded-md border border-gray-200 bg-white shadow-xl"
-                                        style={{
-                                          position: 'fixed',
-                                          top: pickerPosition.top,
-                                          left: pickerPosition.left,
-                                          width: pickerPosition.width
-                                        }}
-                                      >
-                                        <div className="max-h-56 overflow-y-auto p-2 space-y-1">
-                                          {COLUMN_FIELD_OPTIONS.map(option => {
-                                            const fieldMeta = fieldAssignments.find(item => item.field === option.field)
-                                            const isChecked = assignedFields.includes(option.field)
-                                            const isRequired = Boolean(fieldMeta?.required) && fieldMeta?.assignedColumn === null
-                                            const assignedColumnIndex = fieldMeta?.assignedColumn
-                                            const isAssignedElsewhere =
-                                              typeof assignedColumnIndex === 'number' &&
-                                              assignedColumnIndex !== originalIndex
-                                            const assignedDisplayLabel =
-                                              isAssignedElsewhere && typeof assignedColumnIndex === 'number'
-                                                ? getColumnDisplayLabel(assignedColumnIndex)
-                                                : null
-
-                                            return (
-                                              <label
-                                                key={option.field}
-                                                className="flex items-start gap-2 rounded-md px-2 py-1 text-xs hover:bg-gray-50"
-                                              >
-                                                <input
-                                                  type="checkbox"
-                                                  checked={isChecked}
-                                                  onChange={() => toggleFieldForColumn(option.field, originalIndex)}
-                                                  className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                                />
-                                                <div className="flex flex-col">
-                                                  <span className="flex items-center gap-2 text-gray-700">
-                                                    <span aria-hidden>{option.icon}</span>
-                                                    <span>{option.label}</span>
-                                                  </span>
-                                                  {isAssignedElsewhere && assignedDisplayLabel && (
-                                                    <span className="pl-6 text-[11px] text-amber-600">
-                                                      Уже назначено: {assignedDisplayLabel}
-                                                    </span>
-                                                  )}
-                                                  {isRequired && (
-                                                    <span className="pl-6 text-[11px] text-red-600">
-                                                      Обязательное поле
-                                                    </span>
-                                                  )}
-                                                </div>
-                                              </label>
-                                            )
-                                          })}
-                                        </div>
-                                        <div className="border-t border-gray-100 px-3 py-2 text-xs text-gray-600">
-                                          <button
-                                            type="button"
-                                            onClick={() => toggleColumnHidden(originalIndex)}
-                                            className="flex items-center gap-2 text-left text-gray-700 hover:text-blue-600"
-                                          >
-                                            <span aria-hidden>{hiddenColumns.has(originalIndex) ? '👀' : '🙈'}</span>
-                                            <span>
-                                              {hiddenColumns.has(originalIndex)
-                                                ? 'Показать столбец'
-                                                : 'Скрыть столбец'}
-                                            </span>
-                                          </button>
-                                          <p className="mt-1 text-[11px] text-gray-400">
-                                            Скрытые столбцы не будут мешать, вы всегда можете вернуть их ниже.
-                                          </p>
-                                        </div>
-                                      </div>
-                                    ),
-                                    document.body
-                                  )
-                                : null}
-                              <div className="flex min-h-[24px] flex-wrap justify-center gap-1">
-                                {assignedFields.length > 0 ? (
-                                  assignedFields.map(field => (
-                                    <span
-                                      key={field}
-                                      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${FIELD_COLORS[field]}`}
-                                    >
-                                      <span aria-hidden>{FIELD_ICONS[field]}</span>
-                                      <span>{FIELD_LABELS[field]}</span>
-                                    </span>
-                                  ))
-                                ) : (
-                                  <span className="text-xs text-gray-400">Поля не выбраны</span>
-                                )}
-                              </div>
-                            </div>
-                          </th>
+                          <label
+                            key={option.value}
+                            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition ${
+                              checked
+                                ? 'border-blue-400 bg-blue-50 text-blue-700'
+                                : 'border-gray-200 bg-gray-100 text-gray-600'
+                            } ${disabled ? 'opacity-60' : 'cursor-pointer hover:border-blue-300'}`}
+                          >
+                            <input
+                              type="checkbox"
+                              className="h-3 w-3"
+                              checked={checked}
+                              disabled={disabled}
+                              onChange={() => handleToggleField(column.sourceIndex, option.value)}
+                            />
+                            <span>
+                              {option.label}
+                              {option.required && <span className="ml-1 text-red-500">*</span>}
+                            </span>
+                          </label>
                         )
                       })}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sampleData.slice(0, 5).map((row, rowIndex) => (
-                      <tr key={rowIndex} className="border-b hover:bg-gray-50">
-                        {visibleColumnOrder.map(originalIndex => (
-                          <td key={originalIndex} className="px-4 py-3 text-gray-900 whitespace-nowrap">
-                            {row[originalIndex] || '—'}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <div className="px-6 py-8 text-center text-sm text-gray-500">
-                Все столбцы скрыты. Раскройте хотя бы один, чтобы продолжить настройку.
-              </div>
-            )}
-            {sampleData.length > 5 && visibleColumnOrder.length > 0 && (
-              <div className="px-4 py-2 bg-gray-50 text-sm text-gray-600 text-center">
-                ... и еще {sampleData.length - 5} записей
-              </div>
-            )}
-          </div>
-
-          {hiddenColumnOrder.length > 0 && (
-            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-3">
-              <div 
-                className="flex items-center justify-between cursor-pointer"
-                onClick={() => setIsHiddernColumnsVisible(!isHiddernColumnsVisible)}
-              >
-                <div className="flex items-center gap-2">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-600">
-                    Скрытые столбцы ({hiddenColumnOrder.length})
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                    <p className="text-[11px] text-gray-500 hidden sm:block">
-                      Мы запомним их позиции и автоматически спрячем при следующем импорте.
-                    </p>
-                    <span className={`ml-2 text-gray-400 transition-transform ${isHiddernColumnsVisible ? 'rotate-180' : ''}`} aria-hidden>
-                        ▾
-                    </span>
-                </div>
-              </div>
-              {isHiddernColumnsVisible && (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {hiddenColumnOrder.map(originalIndex => {
-                    const columnLabel = getColumnDisplayLabel(originalIndex)
-                    const sampleValue = sampleData[0]?.[originalIndex] || ''
-                    return (
-                      <div
-                        key={originalIndex}
-                        className="flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 shadow-sm"
-                      >
-                        <div className="text-xs font-medium text-gray-700">{columnLabel}</div>
-                        {sampleValue && (
-                          <div
-                            className="max-w-[140px] truncate text-[11px] text-gray-400"
-                            title={sampleValue}
-                          >
-                            {sampleValue}
-                          </div>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => toggleColumnHidden(originalIndex)}
-                        >
-                          Показать
-                        </Button>
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
-          )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 align-top">
+                    <label className="inline-flex items-center gap-2 text-xs text-gray-600">
+                      <input
+                        type="checkbox"
+                        checked={column.hidden}
+                        onChange={() => handleToggleHidden(column.sourceIndex)}
+                      />
+                      Скрыть столбец
+                    </label>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
 
-        {/* Предпросмотр результата */}
-        <div className="mb-6">
-          <div className="flex items-center gap-2 mb-4">
-            <h3 className="font-medium text-gray-900">Предпросмотр результата</h3>
-            <Tooltip content="Посмотрите как будут обработаны ваши данные с текущими настройками">
-              <div className="w-4 h-4 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs cursor-help">
-                ?
-              </div>
-            </Tooltip>
-          </div>
-          
-          {previewData.length > 0 ? (
-            <div className="bg-white border rounded-lg overflow-hidden">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50 border-b">
-                    <tr>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">💰 Сумма</th>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">📝 Описание</th>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">📍 Город</th>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">📅 Дата</th>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">⏰ Время</th>
-                      <th className="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">📋 Примечания</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {previewData.slice(0, 5).map((row, rowIndex) => (
-                      <tr key={rowIndex} className="border-b hover:bg-gray-50">
-                        <td className="px-4 py-3 font-medium text-green-700 whitespace-nowrap">
-                          {row.amount || '—'}
-                        </td>
-                        <td className="px-4 py-3 text-blue-700 whitespace-nowrap">
-                          {row.description || '—'}
-                        </td>
-                        <td className="px-4 py-3 text-indigo-700 whitespace-nowrap">
-                          {row.city || '—'}
-                        </td>
-                        <td className="px-4 py-3 text-purple-700 whitespace-nowrap">
-                          {row.expense_date || '—'}
-                        </td>
-                        <td className="px-4 py-3 text-teal-700 whitespace-nowrap">
-                          {row.expense_time || '—'}
-                        </td>
-                        <td className="px-4 py-3 text-yellow-700 whitespace-nowrap">
-                          {row.notes || '—'}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              {previewData.length > 5 && (
-                <div className="px-4 py-2 bg-gray-50 text-sm text-gray-600 text-center">
-                  ... и еще {previewData.length - 5} записей
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <div className="text-yellow-600">⚠️</div>
-                <div className="text-sm text-yellow-800">
-                  Назначьте хотя бы поля &quot;Сумма&quot; и &quot;Описание&quot; для предпросмотра данных
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Кнопки действий */}
-        <div className="flex justify-between items-center pt-6 border-t">
-          <div className="flex space-x-3">
-            <Tooltip content="Вернуть настройки к значениям по умолчанию">
-              <Button
-                variant="outline"
-                onClick={handleReset}
-                className="text-gray-600"
-              >
-                🔄 Сбросить
-              </Button>
-            </Tooltip>
-          </div>
-          
-          <div className="flex space-x-3">
-            <Button
-              variant="outline"
-              onClick={onClose}
-            >
+        <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-gray-500">
+            Назначьте, какие поля расходов соответствуют каждому столбцу. Обязательные поля помечены *.
+          </p>
+          <div className="flex gap-3 justify-end">
+            <Button variant="outline" onClick={onClose}>
               Отмена
             </Button>
-            
-            {isEditingMode ? (
-              <Tooltip content="Сохранить новые настройки столбцов">
-                <Button
-                  variant="primary"
-                  onClick={handleApply}
-                >
-                  ✅ Применить новые настройки
-                </Button>
-              </Tooltip>
-            ) : (
-              <>
-                <Tooltip content="Применить настройки и продолжить редактирование">
-                  <Button
-                    variant="outline"
-                    onClick={handleApply}
-                    disabled={previewData.length === 0}
-                  >
-                    📝 Применить и редактировать
-                  </Button>
-                </Tooltip>
-                
-                {onApplyAndSave && (
-                  <Tooltip content="Применить настройки и сразу сохранить все расходы">
-                    <Button
-                      variant="primary"
-                      onClick={handleApplyAndSave}
-                      disabled={previewData.length === 0}
-                    >
-                      💾 Применить и сохранить
-                    </Button>
-                  </Tooltip>
-                )}
-              </>
+            <Button variant="secondary" onClick={() => handleApply('apply')}>
+              {isEditingMode ? 'Сохранить' : 'Применить'}
+            </Button>
+            {onApplyAndSave && !isEditingMode && (
+              <Button variant="primary" onClick={() => handleApply('applyAndSave')}>
+                Применить и сохранить
+              </Button>
             )}
           </div>
         </div>

--- a/src/components/expense-input/bulk-input/components/Dropzone.tsx
+++ b/src/components/expense-input/bulk-input/components/Dropzone.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { forwardRef } from 'react'
+
+interface DropzoneProps {
+  isDragOver: boolean
+  onClick: () => void
+  onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
+  onDragOver: (event: React.DragEvent<HTMLDivElement>) => void
+  onDragLeave: (event: React.DragEvent<HTMLDivElement>) => void
+  onDrop: (event: React.DragEvent<HTMLDivElement>) => void
+  onFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export const Dropzone = forwardRef<HTMLInputElement, DropzoneProps>(function Dropzone(
+  { isDragOver, onClick, onPaste, onDragOver, onDragLeave, onDrop, onFileChange },
+  fileInputRef
+) {
+  return (
+    <div
+      className={`relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors cursor-pointer ${
+        isDragOver ? 'bg-blue-50 border-blue-400' : 'bg-white'
+      }`}
+      onPaste={onPaste}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onClick={onClick}
+      tabIndex={0}
+      role="button"
+      aria-label="Загрузить файл"
+    >
+      <div className="flex flex-col items-center gap-2 text-gray-500">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="mx-auto h-12 w-12 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        <span className="mt-2 block text-sm font-semibold text-gray-900">
+          Перетащите файлы сюда или нажмите для загрузки
+        </span>
+        <span className="block text-xs text-gray-500">
+          CSV, Excel, HTML или просто вставьте из буфера обмена
+        </span>
+      </div>
+      <input ref={fileInputRef} type="file" accept="*/*" onChange={onFileChange} className="hidden" />
+    </div>
+  )
+})

--- a/src/components/expense-input/bulk-input/components/ReviewModal.tsx
+++ b/src/components/expense-input/bulk-input/components/ReviewModal.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { Modal } from '@/components/ui/Modal'
+import { Button } from '@/components/ui/Button'
+import type { BuildExpensesResult, CityReviewItem } from '../types'
+
+interface ReviewModalProps {
+  state: { mode: 'append' | 'directSave'; result: BuildExpensesResult } | null
+  isProcessing: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ReviewModal({ state, isProcessing, onConfirm, onCancel }: ReviewModalProps) {
+  const cityItems: CityReviewItem[] = state?.result.reviewItems.filter(
+    (item): item is CityReviewItem => item.type === 'city-from-description'
+  ) ?? []
+  const totalReviewCount = cityItems.length
+  const cityPreview = cityItems.slice(0, 6)
+  const cityOverflow = cityItems.length - cityPreview.length
+
+  const primaryLabel = state?.mode === 'directSave'
+    ? (isProcessing ? 'Сохранение...' : 'Подтвердить и сохранить')
+    : 'Подтвердить импорт'
+
+  return (
+    <Modal
+      isOpen={Boolean(state)}
+      onClose={onCancel}
+      title="Проверка автоматически выделенных полей"
+      size="xl"
+    >
+      {state && (
+        <div className="space-y-6">
+          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 text-sm text-blue-900">
+            Система выделила дополнительные данные в {totalReviewCount}{' '}
+            {totalReviewCount === 1 ? 'строке' : 'строках'}. Проверьте результаты и подтвердите, что всё выглядит корректно.
+          </div>
+
+          {cityItems.length > 0 && (
+            <div className="space-y-3">
+              <div className="inline-flex items-center gap-2 rounded-full bg-blue-100 text-blue-800 px-3 py-1 text-sm">
+                📍 Города из описания: {cityItems.length}
+              </div>
+
+              <div className="overflow-hidden rounded-lg border border-gray-200">
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                      <tr>
+                        <th className="px-3 py-2 text-left">Строка</th>
+                        <th className="px-3 py-2 text-left">Столбец</th>
+                        <th className="px-3 py-2 text-left">Исходное значение</th>
+                        <th className="px-3 py-2 text-left">Описание после очистки</th>
+                        <th className="px-3 py-2 text-left">Автоопределённый город</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200">
+                      {cityPreview.map(item => (
+                        <tr key={`${item.rowIndex}-${item.columnLabel}`} className="bg-white">
+                          <td className="px-3 py-2 align-top text-gray-500">{item.rowIndex}</td>
+                          <td className="px-3 py-2 align-top text-gray-700">{item.columnLabel}</td>
+                          <td className="px-3 py-2 align-top text-gray-900 whitespace-pre-wrap break-words">
+                            {item.sourceValue || '—'}
+                          </td>
+                          <td className="px-3 py-2 align-top text-gray-900 whitespace-pre-wrap break-words">
+                            {item.cleanedDescription || '—'}
+                          </td>
+                          <td className="px-3 py-2 align-top text-blue-700 font-semibold">
+                            {item.extractedCity}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {cityOverflow > 0 && (
+                  <div className="px-3 py-2 text-xs text-gray-500 bg-gray-50">
+                    и ещё {cityOverflow} {cityOverflow === 1 ? 'строка' : 'строк'} с автоопределением города
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 border-t border-gray-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-gray-500">
+              Подтверждение применит назначенные столбцы и перенесёт данные в таблицу расходов.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <Button variant="outline" onClick={onCancel} disabled={isProcessing}>
+                Вернуться
+              </Button>
+              <Button variant="primary" onClick={onConfirm} disabled={isProcessing}>
+                {primaryLabel}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/expense-input/bulk-input/components/TablePreviewModal.tsx
+++ b/src/components/expense-input/bulk-input/components/TablePreviewModal.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Modal } from '@/components/ui/Modal'
+
+interface TablePreviewModalProps {
+  isOpen: boolean
+  table: { description: string; rows: string[][] } | null
+  onClose: () => void
+}
+
+export function TablePreviewModal({ isOpen, table, onClose }: TablePreviewModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={table ? `Предпросмотр: ${table.description}` : 'Предпросмотр таблицы'}
+      size="xl"
+    >
+      {table && (
+        <div className="max-h-[70vh] overflow-auto border border-gray-200 rounded-lg">
+          <table className="min-w-full text-xs border-collapse">
+            <thead className="sticky top-0 bg-gray-100 z-10">
+              {table.rows[0] && (
+                <tr>
+                  {table.rows[0].map((cell, cellIndex) => (
+                    <th
+                      key={cellIndex}
+                      className="border-b border-gray-300 p-2 text-left font-semibold text-gray-700"
+                    >
+                      {cell}
+                    </th>
+                  ))}
+                </tr>
+              )}
+            </thead>
+            <tbody>
+              {table.rows.slice(1).map((row, rowIndex) => (
+                <tr key={rowIndex} className="even:bg-gray-50">
+                  {row.map((cell, cellIndex) => (
+                    <td key={cellIndex} className="border-b border-gray-200 p-2">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/expense-input/bulk-input/components/TableSelectionModal.tsx
+++ b/src/components/expense-input/bulk-input/components/TableSelectionModal.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { Modal } from '@/components/ui/Modal'
+import { Button } from '@/components/ui/Button'
+import type { TableInfo } from '@/lib/utils/bankStatementParsers'
+
+interface TableSelectionModalProps {
+  isOpen: boolean
+  tables: TableInfo[]
+  savedIndex: number | null
+  isLoading: boolean
+  onSelect: (index: number) => void
+  onClose: () => void
+  onPreview: (index: number) => void
+}
+
+export function TableSelectionModal({
+  isOpen,
+  tables,
+  savedIndex,
+  isLoading,
+  onSelect,
+  onClose,
+  onPreview
+}: TableSelectionModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Выбор таблицы" size="xl">
+      {tables.length > 0 && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Найдено {tables.length} таблиц. Выберите таблицу для импорта:
+          </p>
+
+          <div className="space-y-3 max-h-96 overflow-y-auto">
+            {tables.map((table, index) => {
+              const isSaved = savedIndex === index
+              return (
+                <div
+                  key={table.index}
+                  className={`p-4 border rounded-lg transition-colors ${
+                    isSaved ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                  } ${isLoading ? 'cursor-wait opacity-60' : 'cursor-pointer'}`}
+                  tabIndex={isLoading ? -1 : 0}
+                  onClick={() => !isLoading && onSelect(index)}
+                  onKeyDown={event => {
+                    if (!isLoading && (event.key === 'Enter' || event.key === ' ')) {
+                      event.preventDefault()
+                      onSelect(index)
+                    }
+                  }}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex-1">
+                      <h3 className="font-medium text-gray-900">{table.description}</h3>
+                      <p className="text-sm text-gray-500">
+                        {table.rowCount} строк, {table.columnCount} столбцов
+                      </p>
+                      <p className="mt-1 text-xs text-gray-500">
+                        {table.hasHeaders ? 'Содержит строку заголовков' : 'Без отдельной строки заголовков'}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      {isSaved && <span className="text-blue-600 text-sm font-medium">✓ Ранее</span>}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={event => {
+                          event.stopPropagation()
+                          onPreview(index)
+                        }}
+                      >
+                        Предпросмотр
+                      </Button>
+                    </div>
+                  </div>
+
+                  {table.preview.length > 0 && (
+                    <div className="mt-3 overflow-hidden rounded-md border bg-white">
+                      <div className="overflow-x-auto">
+                        <table className="min-w-full divide-y divide-gray-200 text-xs">
+                          <tbody className="divide-y divide-gray-100">
+                            {table.preview.map((previewRow, previewIndex) => (
+                              <tr key={previewIndex} className="bg-white">
+                                {previewRow.map((cell, cellIndex) => (
+                                  <td
+                                    key={cellIndex}
+                                    className={`px-3 py-2 whitespace-nowrap ${
+                                      previewIndex === 0 ? 'font-medium text-gray-900' : 'text-gray-600'
+                                    }`}
+                                  >
+                                    {cell || '—'}
+                                  </td>
+                                ))}
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-4 border-t">
+            <Button variant="outline" onClick={onClose}>
+              Отмена
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/expense-input/bulk-input/types.ts
+++ b/src/components/expense-input/bulk-input/types.ts
@@ -1,0 +1,42 @@
+import type { TableInfo } from '@/lib/utils/bankStatementParsers'
+import type { BulkExpenseRowData } from '@/lib/validations/expenses'
+import type { ColumnMapping, ColumnMappingField } from '@/types'
+
+export type SelectedTableMeta = Pick<
+  TableInfo,
+  'index' | 'description' | 'rowCount' | 'columnCount' | 'hasHeaders'
+>
+
+export type AutoExtractionReviewItem = {
+  type: 'city-from-description'
+  rowIndex: number
+  columnLabel: string
+  sourceValue: string
+  extractedCity: string
+  cleanedDescription: string
+}
+
+export type CityReviewItem = AutoExtractionReviewItem
+
+export interface BuildExpensesStats {
+  totalRows: number
+  importedRows: number
+  skippedRows: number
+  autoDetectedCities: number
+  manualCities: number
+  detectedTimes: number
+  manualTimes: number
+}
+
+export interface BuildExpensesResult {
+  expenses: BulkExpenseRowData[]
+  stats: BuildExpensesStats
+  reviewItems: AutoExtractionReviewItem[]
+}
+
+export type ColumnMappingWithMeta = ColumnMapping & {
+  columnIndex: number
+  columnLabel: string
+  targetFields: ColumnMappingField[]
+  hidden: boolean
+}

--- a/src/components/expense-input/bulk-input/useColumnMapping.ts
+++ b/src/components/expense-input/bulk-input/useColumnMapping.ts
@@ -1,117 +1,124 @@
 'use client'
 
-import { useState, useCallback } from 'react';
-import { useToast } from '@/hooks/useToast';
-import type { ColumnMapping, ColumnMappingField } from '@/types';
-
-const COLUMN_MAPPING_FIELDS: ColumnMappingField[] = ['amount', 'description', 'city', 'expense_date', 'expense_time', 'notes'];
-const COLUMN_MAPPING_FIELD_SET = new Set<ColumnMappingField>(COLUMN_MAPPING_FIELDS);
-
-function isColumnMappingField(value: unknown): value is ColumnMappingField {
-  return typeof value === 'string' && COLUMN_MAPPING_FIELD_SET.has(value as ColumnMappingField);
-}
-
-function normalizeColumnMapping(raw: unknown): ColumnMapping[] {
-  if (!Array.isArray(raw)) return [];
-  return raw.map((item, index) => {
-    const candidate = item as Partial<ColumnMapping> & { targetField?: unknown };
-    const directTargets = Array.isArray(candidate?.targetFields) ? candidate.targetFields.filter(isColumnMappingField) : [];
-    const legacyTarget = isColumnMappingField(candidate?.targetField) ? [candidate.targetField] : [];
-    const uniqueTargets = Array.from(new Set([...directTargets, ...legacyTarget]));
-    const normalizedTargets = uniqueTargets.filter(isColumnMappingField);
-    const normalizedEnabled = typeof candidate?.enabled === 'boolean' ? candidate.enabled && normalizedTargets.length > 0 : normalizedTargets.length > 0;
-    return {
-      sourceIndex: typeof candidate?.sourceIndex === 'number' ? candidate.sourceIndex : index,
-      targetFields: normalizedEnabled ? normalizedTargets : [],
-      enabled: normalizedEnabled && normalizedTargets.length > 0,
-      preview: typeof candidate?.preview === 'string' ? candidate.preview : '',
-      hidden: Boolean(candidate?.hidden)
-    };
-  });
-}
-
-function sanitizeColumnMapping(mapping: ColumnMapping[]): ColumnMapping[] {
-  return normalizeColumnMapping(mapping);
-}
+import { useState, useCallback } from 'react'
+import { useToast } from '@/hooks/useToast'
+import type { ColumnMapping } from '@/types'
+import type { BuildExpensesResult } from './types'
+import {
+  sanitizeColumnMapping,
+  COLUMN_MAPPING_STORAGE_KEY
+} from './utils/columnMapping'
 
 interface UseColumnMappingProps {
-  buildExpensesFromMappedData: (mapping: ColumnMapping[]) => any; 
-  appendExpensesWithStats: (result: any) => void;
-  saveImportedExpenses: (result: any, fileName: string) => Promise<boolean>;
-  fileName: string;
-  setReviewModalState: (state: any) => void;
-  isColumnMappingOpen: boolean;
-  setIsColumnMappingOpen: (isOpen: boolean) => void;
-  isEditingColumnMapping: boolean;
-  setIsEditingColumnMapping: (isEditing: boolean) => void;
+  buildExpensesFromMappedData: (mapping: ColumnMapping[]) => BuildExpensesResult
+  appendExpensesWithStats: (result: BuildExpensesResult) => void
+  saveImportedExpenses: (result: BuildExpensesResult) => Promise<boolean>
+  setReviewModalState: (state: { mode: 'append' | 'directSave'; result: BuildExpensesResult } | null) => void
+  isEditingColumnMapping: boolean
 }
 
-export function useColumnMapping({ 
-  buildExpensesFromMappedData, 
-  appendExpensesWithStats, 
-  saveImportedExpenses, 
-  fileName, 
+export function useColumnMapping({
+  buildExpensesFromMappedData,
+  appendExpensesWithStats,
+  saveImportedExpenses,
   setReviewModalState,
-  isColumnMappingOpen,
-  setIsColumnMappingOpen,
-  isEditingColumnMapping,
-  setIsEditingColumnMapping
+  isEditingColumnMapping
 }: UseColumnMappingProps) {
-  const { showToast } = useToast();
-  const [savedColumnMapping, setSavedColumnMapping] = useState<ColumnMapping[] | null>(null);
+  const { showToast } = useToast()
+  const [savedColumnMapping, setSavedColumnMapping] = useState<ColumnMapping[] | null>(null)
 
   const loadSavedColumnMapping = useCallback(() => {
     try {
-      const saved = localStorage.getItem('columnMapping');
+      const saved = localStorage.getItem(COLUMN_MAPPING_STORAGE_KEY)
       if (saved) {
-        const parsed = JSON.parse(saved);
-        const sanitized = sanitizeColumnMapping(parsed);
-        setSavedColumnMapping(sanitized);
-        return sanitized;
+        const parsed = JSON.parse(saved)
+        const sanitized = sanitizeColumnMapping(parsed)
+        setSavedColumnMapping(sanitized)
+        return sanitized
       }
     } catch (error) {
-      console.warn('Ошибка загрузки сохраненного сопоставления столбцов:', error);
+      console.warn('Ошибка загрузки сохраненной схемы столбцов:', error)
     }
-    return [];
-  }, []);
+    setSavedColumnMapping(null)
+    return []
+  }, [])
 
   const saveColumnMapping = useCallback((mapping: ColumnMapping[]) => {
     try {
-      const sanitized = sanitizeColumnMapping(mapping);
-      localStorage.setItem('columnMapping', JSON.stringify(sanitized));
-      setSavedColumnMapping(sanitized);
-      showToast('Настройки столбцов сохранены', 'success');
+      const sanitized = sanitizeColumnMapping(mapping)
+      localStorage.setItem(COLUMN_MAPPING_STORAGE_KEY, JSON.stringify(sanitized))
+      setSavedColumnMapping(sanitized.length > 0 ? sanitized : null)
     } catch (error) {
-      console.warn('Ошибка сохранения сопоставления столбцов:', error);
-      showToast('Не удалось сохранить настройки столбцов', 'error');
+      console.warn('Ошибка сохранения схемы столбцов:', error)
     }
-  }, [showToast]);
+  }, [])
 
-  const handleColumnMappingApply = useCallback((mapping: ColumnMapping[]) => {
-    const result = buildExpensesFromMappedData(mapping);
-    appendExpensesWithStats(result);
-    setIsColumnMappingOpen(false);
-  }, [buildExpensesFromMappedData, appendExpensesWithStats, setIsColumnMappingOpen]);
+  const handleColumnMappingApply = useCallback(
+    (mapping: ColumnMapping[]) => {
+      saveColumnMapping(mapping)
 
-  const handleColumnMappingApplyAndSave = useCallback(async (mapping: ColumnMapping[]) => {
-    saveColumnMapping(mapping);
-    const result = buildExpensesFromMappedData(mapping);
-    if (result.expenses.length === 0) {
-      showToast('Не удалось обработать данные с текущими настройками столбцов', 'error');
-      return;
-    }
-    if (result.reviewItems.length > 0) {
-      setReviewModalState({ mode: 'directSave', result });
-      showToast('Найдены автоматически выделенные поля. Подтвердите сохранение.', 'info');
-      return;
-    }
-    await saveImportedExpenses(result, fileName);
-  }, [buildExpensesFromMappedData, saveImportedExpenses, fileName, setReviewModalState, saveColumnMapping, showToast]);
+      if (isEditingColumnMapping) {
+        showToast('Настройки столбцов сохранены', 'success')
+        return
+      }
+
+      const result = buildExpensesFromMappedData(mapping)
+
+      if (result.expenses.length === 0) {
+        showToast('Не удалось обработать данные с текущими настройками столбцов', 'error')
+        return
+      }
+
+      if (result.reviewItems.length > 0) {
+        setReviewModalState({ mode: 'append', result })
+        showToast('Найдены автоматически выделенные поля. Подтвердите импорт.', 'info')
+        return
+      }
+
+      appendExpensesWithStats(result)
+    },
+    [
+      appendExpensesWithStats,
+      buildExpensesFromMappedData,
+      isEditingColumnMapping,
+      saveColumnMapping,
+      setReviewModalState,
+      showToast
+    ]
+  )
+
+  const handleColumnMappingApplyAndSave = useCallback(
+    async (mapping: ColumnMapping[]) => {
+      saveColumnMapping(mapping)
+
+      const result = buildExpensesFromMappedData(mapping)
+
+      if (result.expenses.length === 0) {
+        showToast('Не удалось обработать данные с текущими настройками столбцов', 'error')
+        return
+      }
+
+      if (result.reviewItems.length > 0) {
+        setReviewModalState({ mode: 'directSave', result })
+        showToast('Найдены автоматически выделенные поля. Подтвердите сохранение.', 'info')
+        return
+      }
+
+      await saveImportedExpenses(result)
+    },
+    [
+      buildExpensesFromMappedData,
+      saveColumnMapping,
+      saveImportedExpenses,
+      setReviewModalState,
+      showToast
+    ]
+  )
 
   return {
     savedColumnMapping,
     loadSavedColumnMapping,
     handleColumnMappingApply,
-    handleColumnMappingApplyAndSave,
-  };
+    handleColumnMappingApplyAndSave
+  }
 }

--- a/src/components/expense-input/bulk-input/useExpenseBuilder.ts
+++ b/src/components/expense-input/bulk-input/useExpenseBuilder.ts
@@ -1,99 +1,359 @@
 'use client'
 
-import { useState, useCallback } from 'react';
-import { useToast } from '@/hooks/useToast';
-import { getCurrentDateISO } from '@/lib/utils/dateUtils';
-import { extractCityFromDescription } from '@/lib/utils/cityParser';
-import { parseDateAndTime, parseAmount, parseTimeValue } from '@/lib/utils/bankStatementParsers';
-import { bulkExpenseRowSchema, type BulkExpenseRowData } from '@/lib/validations/expenses';
-import type { ColumnMapping } from '@/types';
-import type { CityOption } from '@/lib/utils/cityOptions';
+import { useState, useCallback } from 'react'
+import { useToast } from '@/hooks/useToast'
+import { getCurrentDateISO } from '@/lib/utils/dateUtils'
+import { extractCityFromDescription } from '@/lib/utils/cityParser'
+import {
+  parseAmount,
+  parseDateAndTime,
+  parseTimeValue
+} from '@/lib/utils/bankStatementParsers'
+import {
+  bulkExpenseRowSchema,
+  type BulkExpenseRowData
+} from '@/lib/validations/expenses'
+import type { ColumnMapping } from '@/types'
+import type { CityOption } from '@/lib/utils/cityOptions'
+import {
+  sanitizeColumnMapping,
+  getColumnLabel
+} from './utils/columnMapping'
+import type {
+  AutoExtractionReviewItem,
+  BuildExpensesResult,
+  BuildExpensesStats
+} from './types'
 
-// Helper function
 function normalizeRow(row: string[] = []): string[] {
-  return row.map(cell => (cell ?? '').trim());
+  return row.map(cell => (cell ?? '').trim())
 }
 
 interface UseExpenseBuilderProps {
-  pastedData: string[][];
-  hasHeaderRow: boolean;
-  resolveCityByInput: (value: string) => CityOption | null;
+  pastedData: string[][]
+  hasHeaderRow: boolean
+  resolveCityByInput: (value: string) => CityOption | null
+  onDatasetConsumed?: () => void
 }
 
-export function useExpenseBuilder({ pastedData, hasHeaderRow, resolveCityByInput }: UseExpenseBuilderProps) {
-  const { showToast } = useToast();
-  const [expenses, setExpenses] = useState<BulkExpenseRowData[]>([]);
-  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+export function useExpenseBuilder({
+  pastedData,
+  hasHeaderRow,
+  resolveCityByInput,
+  onDatasetConsumed
+}: UseExpenseBuilderProps) {
+  const { showToast } = useToast()
+  const [expenses, setExpenses] = useState<BulkExpenseRowData[]>([])
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({})
 
   const addRow = useCallback(() => {
-    const newRow: BulkExpenseRowData = { amount: 0, description: '', notes: '', category_id: '', expense_date: getCurrentDateISO(), expense_time: '', city: '', city_id: null, tempId: crypto.randomUUID() };
-    setExpenses(prev => [...prev, newRow]);
-  }, []);
+    const newRow: BulkExpenseRowData = {
+      amount: 0,
+      description: '',
+      notes: '',
+      category_id: '',
+      expense_date: getCurrentDateISO(),
+      expense_time: '',
+      city: '',
+      city_id: null,
+      tempId: crypto.randomUUID()
+    }
+    setExpenses(prev => [...prev, newRow])
+  }, [])
 
   const removeRow = useCallback((tempId: string) => {
-    setExpenses(prev => prev.filter(expense => expense.tempId !== tempId));
-  }, []);
+    setExpenses(prev => prev.filter(expense => expense.tempId !== tempId))
+    setValidationErrors(prev => {
+      const next = { ...prev }
+      Object.keys(next).forEach(key => {
+        if (key.startsWith(`${tempId}-`)) {
+          delete next[key]
+        }
+      })
+      return next
+    })
+  }, [])
 
-  const updateRow = useCallback((tempId: string, field: keyof BulkExpenseRowData, value: any) => {
-    setExpenses(prev => prev.map(expense => expense.tempId === tempId ? { ...expense, [field]: value } : expense));
-  }, []);
+  const updateRow = useCallback(
+    (tempId: string, field: keyof BulkExpenseRowData, value: unknown) => {
+      setExpenses(prev =>
+        prev.map(expense =>
+          expense.tempId === tempId ? { ...expense, [field]: value } : expense
+        )
+      )
+      setValidationErrors(prev => {
+        const key = `${tempId}-${field}`
+        if (!prev[key]) {
+          return prev
+        }
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    },
+    []
+  )
 
   const handleClear = useCallback(() => {
-    setExpenses([]);
-    setValidationErrors({});
-  }, []);
-
-  const buildExpensesFromMappedData = useCallback((mapping: ColumnMapping[]) => {
-    // This is a simplified version of the logic that should be here
-    // In a real scenario, the full implementation from the original file would be moved here.
-    showToast('Building expenses from mapped data...', 'info');
-    const newExpenses: BulkExpenseRowData[] = pastedData.slice(hasHeaderRow ? 1 : 0).map((row, i) => ({
-        tempId: crypto.randomUUID(),
-        amount: parseFloat(row[0]) || 0,
-        description: row[1] || `Description ${i}`,
-        expense_date: getCurrentDateISO(),
-        notes: '',
-        category_id: '',
-        expense_time: '',
-        city: '',
-        city_id: null,
-    }));
-    return { expenses: newExpenses, stats: {}, reviewItems: [] };
-  }, [pastedData, hasHeaderRow, showToast]);
-
-  const appendSingleColumnExpenses = useCallback((rows: string[][], hasHeader: boolean, sourceLabel: string) => {
-    const dataRows = (hasHeader ? rows.slice(1) : rows).map(normalizeRow).filter(row => row[0] && row[0].trim());
-    if (dataRows.length === 0) {
-      showToast('Не найдены значения для описания', 'warning');
-      return 0;
-    }
-    const newExpenses: BulkExpenseRowData[] = dataRows.map(row => ({ amount: 0, description: row[0].trim(), city: '', city_id: null, notes: '', category_id: '', expense_date: getCurrentDateISO(), expense_time: '', tempId: crypto.randomUUID() }));
-    setExpenses(prev => [...prev, ...newExpenses]);
-    showToast(`Добавлено ${newExpenses.length} описаний из ${sourceLabel}`, 'success');
-    return newExpenses.length;
-  }, [showToast]);
+    setExpenses([])
+    setValidationErrors({})
+  }, [])
 
   const validateExpenses = useCallback(() => {
-    const newErrors: Record<string, string> = {};
-    let allValid = true;
+    const nextErrors: Record<string, string> = {}
+    let isValid = true
 
     for (const expense of expenses) {
-      const result = bulkExpenseRowSchema.safeParse(expense);
+      const result = bulkExpenseRowSchema.safeParse(expense)
       if (!result.success) {
-        allValid = false;
-        const fieldErrors = result.error.flatten().fieldErrors;
-        for (const key in fieldErrors) {
-          const typedKey = key as keyof typeof fieldErrors;
-          if (fieldErrors[typedKey] && expense.tempId) {
-            newErrors[`${expense.tempId}-${typedKey}`] = fieldErrors[typedKey]![0];
+        isValid = false
+        const fieldErrors = result.error.flatten().fieldErrors
+        for (const key of Object.keys(fieldErrors)) {
+          const typedKey = key as keyof typeof fieldErrors
+          const messages = fieldErrors[typedKey]
+          if (messages && messages[0] && expense.tempId) {
+            nextErrors[`${expense.tempId}-${typedKey}`] = messages[0]
           }
         }
       }
     }
 
-    setValidationErrors(newErrors);
-    return allValid;
-  }, [expenses]);
+    setValidationErrors(nextErrors)
+    return isValid
+  }, [expenses])
+
+  const appendSingleColumnExpenses = useCallback(
+    (rows: string[][], headerPresent: boolean, sourceLabel: string) => {
+      const dataRows = (headerPresent ? rows.slice(1) : rows)
+        .map(normalizeRow)
+        .filter(row => row[0] && row[0].trim())
+
+      if (dataRows.length === 0) {
+        showToast('Не найдены значения для описания', 'warning')
+        return 0
+      }
+
+      const newExpenses: BulkExpenseRowData[] = dataRows.map(row => ({
+        amount: 0,
+        description: row[0].trim(),
+        city: '',
+        city_id: null,
+        notes: '',
+        category_id: '',
+        expense_date: getCurrentDateISO(),
+        expense_time: '',
+        tempId: crypto.randomUUID()
+      }))
+
+      setExpenses(prev => [...prev, ...newExpenses])
+      showToast(`Добавлено ${newExpenses.length} описаний из ${sourceLabel}`, 'success')
+      return newExpenses.length
+    },
+    [showToast]
+  )
+
+  const buildExpensesFromMappedData = useCallback(
+    (mapping: ColumnMapping[]): BuildExpensesResult => {
+      const stats: BuildExpensesStats = {
+        totalRows: 0,
+        importedRows: 0,
+        skippedRows: 0,
+        autoDetectedCities: 0,
+        manualCities: 0,
+        detectedTimes: 0,
+        manualTimes: 0
+      }
+
+      if (pastedData.length === 0) {
+        return { expenses: [], stats, reviewItems: [] }
+      }
+
+      const headerRow = hasHeaderRow ? pastedData[0] : null
+
+      const mappingWithMeta = sanitizeColumnMapping(mapping).map((column, columnIndex) => ({
+        ...column,
+        columnIndex,
+        columnLabel: getColumnLabel(columnIndex, headerRow),
+        targetFields: Array.isArray(column.targetFields) ? column.targetFields : [],
+        hidden: Boolean(column.hidden)
+      }))
+
+      const rowsToProcess = (hasHeaderRow ? pastedData.slice(1) : pastedData)
+        .map(normalizeRow)
+        .filter(row => row.some(cell => cell && cell.trim().length > 0))
+
+      stats.totalRows = rowsToProcess.length
+
+      const newExpenses: BulkExpenseRowData[] = []
+      const reviewItems: AutoExtractionReviewItem[] = []
+
+      rowsToProcess.forEach((row, dataRowIndex) => {
+        const expenseDraft: Partial<BulkExpenseRowData> & {
+          expense_time?: string | null
+        } = {
+          tempId: crypto.randomUUID()
+        }
+
+        let descriptionColumnLabel: string | null = null
+        let descriptionSourceValue = ''
+        let descriptionColumnIndex: number | null = null
+
+        mappingWithMeta.forEach(column => {
+          if (column.hidden || !column.enabled || column.targetFields.length === 0) {
+            return
+          }
+
+          const cellValue = row[column.columnIndex]?.trim() || ''
+          if (!cellValue) {
+            return
+          }
+
+          column.targetFields.forEach(targetField => {
+            switch (targetField) {
+              case 'amount': {
+                try {
+                  const parsedAmount = parseAmount(cellValue)
+                  const normalizedAmount = Math.abs(parsedAmount)
+                  if (normalizedAmount > 0) {
+                    expenseDraft.amount = normalizedAmount
+                  }
+                } catch (error) {
+                  console.warn('Не удалось распарсить сумму из столбца', cellValue, error)
+                }
+                break
+              }
+              case 'description':
+                expenseDraft.description = cellValue
+                descriptionColumnLabel = column.columnLabel
+                descriptionSourceValue = cellValue
+                descriptionColumnIndex = column.columnIndex
+                break
+              case 'city':
+                expenseDraft.city = cellValue
+                break
+              case 'expense_date': {
+                const dateTimeResult = parseDateAndTime(cellValue)
+                expenseDraft.expense_date = dateTimeResult.date
+                if (dateTimeResult.time && !expenseDraft.expense_time) {
+                  expenseDraft.expense_time = dateTimeResult.time
+                  stats.detectedTimes += 1
+                }
+                break
+              }
+              case 'expense_time': {
+                if (expenseDraft.expense_time) {
+                  break
+                }
+                const parsedTime = parseTimeValue(cellValue)
+                if (parsedTime) {
+                  expenseDraft.expense_time = parsedTime
+                  stats.manualTimes += 1
+                }
+                break
+              }
+              case 'notes':
+                expenseDraft.notes = cellValue
+                break
+            }
+          })
+        })
+
+        if (expenseDraft.amount && expenseDraft.description) {
+          let cleanDescription = expenseDraft.description.trim()
+          let notes = expenseDraft.notes?.trim() || ''
+          let detectedCity: string | null = null
+
+          if (cleanDescription) {
+            const cityParseResult = extractCityFromDescription(cleanDescription)
+            if (cityParseResult.confidence > 0.6) {
+              cleanDescription = cityParseResult.cleanDescription
+              if (!expenseDraft.city && cityParseResult.displayCity) {
+                detectedCity = cityParseResult.displayCity
+              }
+            }
+          }
+
+          const providedCity = expenseDraft.city?.trim()
+          let finalCity = providedCity || detectedCity || ''
+          let resolvedCityId: string | null = null
+
+          if (providedCity) {
+            stats.manualCities += 1
+            const resolved = resolveCityByInput(providedCity)
+            if (resolved) {
+              finalCity = resolved.cityName
+              resolvedCityId = resolved.cityId
+            }
+          } else if (detectedCity) {
+            stats.autoDetectedCities += 1
+            const resolved = resolveCityByInput(detectedCity)
+            if (resolved) {
+              finalCity = resolved.cityName
+              resolvedCityId = resolved.cityId
+            }
+
+            const reviewNote = `Автодетект города: ${finalCity || detectedCity}`
+            if (!notes.includes(reviewNote)) {
+              notes = notes ? `${notes}\n${reviewNote}` : reviewNote
+            }
+
+            reviewItems.push({
+              type: 'city-from-description',
+              rowIndex: dataRowIndex + 1,
+              columnLabel:
+                descriptionColumnLabel || getColumnLabel(descriptionColumnIndex ?? 0, headerRow),
+              sourceValue: descriptionSourceValue,
+              extractedCity: finalCity || detectedCity,
+              cleanedDescription: cleanDescription
+            })
+          }
+
+          newExpenses.push({
+            amount: expenseDraft.amount,
+            description: cleanDescription,
+            notes,
+            category_id: '',
+            expense_date: expenseDraft.expense_date || getCurrentDateISO(),
+            expense_time: expenseDraft.expense_time || null,
+            city: finalCity,
+            city_id: resolvedCityId,
+            tempId: expenseDraft.tempId!
+          })
+        }
+      })
+
+      stats.importedRows = newExpenses.length
+      stats.skippedRows = Math.max(stats.totalRows - stats.importedRows, 0)
+
+      return { expenses: newExpenses, stats, reviewItems }
+    },
+    [hasHeaderRow, pastedData, resolveCityByInput]
+  )
+
+  const appendExpensesWithStats = useCallback(
+    (result: BuildExpensesResult) => {
+      const { expenses: newExpenses, stats } = result
+      setExpenses(prev => [...prev, ...newExpenses])
+      onDatasetConsumed?.()
+
+      showToast(`Добавлено ${newExpenses.length} из ${stats.totalRows} записей`, 'success')
+
+      if (stats.autoDetectedCities > 0 || stats.detectedTimes > 0 || stats.manualTimes > 0) {
+        const details: string[] = []
+        if (stats.autoDetectedCities > 0) {
+          details.push(`автогорода: ${stats.autoDetectedCities}`)
+        }
+        if (stats.manualTimes + stats.detectedTimes > 0) {
+          details.push(`время: ${stats.manualTimes + stats.detectedTimes}`)
+        }
+        const suffix = details.length > 0 ? ` (${details.join(', ')})` : ''
+        showToast(`Пожалуйста, подтвердите автоматически заполненные поля${suffix}.`, 'info')
+      } else {
+        showToast('Проверьте импортированные данные перед сохранением.', 'info')
+      }
+    },
+    [onDatasetConsumed, showToast]
+  )
 
   return {
     expenses,
@@ -104,9 +364,9 @@ export function useExpenseBuilder({ pastedData, hasHeaderRow, resolveCityByInput
     removeRow,
     updateRow,
     handleClear,
-    buildExpensesFromMappedData,
+    validateExpenses,
     appendSingleColumnExpenses,
-    validateExpenses
-  };
+    buildExpensesFromMappedData,
+    appendExpensesWithStats
+  }
 }
-

--- a/src/components/expense-input/bulk-input/useExpenseSubmit.ts
+++ b/src/components/expense-input/bulk-input/useExpenseSubmit.ts
@@ -1,110 +1,163 @@
 'use client'
 
-import { useState, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { useToast } from '@/hooks/useToast';
-import { createBulkExpenses } from '@/lib/actions/expenses';
-import { createBankStatement } from '@/lib/actions/bankStatements';
-import type { CreateExpenseData } from '@/types';
-import type { BulkExpenseRowData } from '@/lib/validations/expenses';
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useToast } from '@/hooks/useToast'
+import { createBulkExpenses } from '@/lib/actions/expenses'
+import { createBankStatement } from '@/lib/actions/bankStatements'
+import type { CreateExpenseData } from '@/types'
+import type { BulkExpenseRowData } from '@/lib/validations/expenses'
+import type { BuildExpensesResult } from './types'
 
 interface UseExpenseSubmitProps {
-  expenses: BulkExpenseRowData[];
-  autoRedirect: boolean;
-  validateExpenses: () => boolean;
-  clearForm: () => void;
+  expenses: BulkExpenseRowData[]
+  autoRedirect: boolean
+  validateExpenses: () => boolean
+  clearExpenses: () => void
+  resetFileState: () => void
+  onDatasetSaved: (result: BuildExpensesResult) => void
+  fileName: string
 }
 
-export function useExpenseSubmit({ expenses, autoRedirect, validateExpenses, clearForm }: UseExpenseSubmitProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [reviewModalState, setReviewModalState] = useState<any | null>(null);
-  const [isReviewProcessing, setIsReviewProcessing] = useState(false);
-  const router = useRouter();
-  const { showToast } = useToast();
+export function useExpenseSubmit({
+  expenses,
+  autoRedirect,
+  validateExpenses,
+  clearExpenses,
+  resetFileState,
+  onDatasetSaved,
+  fileName
+}: UseExpenseSubmitProps) {
+  const router = useRouter()
+  const { showToast } = useToast()
 
-  const saveImportedExpenses = useCallback(async (result: any, fileName?: string) => {
-    const { expenses: newExpenses } = result;
-    let batchId: string | undefined = undefined;
-    if (fileName) {
-      batchId = crypto.randomUUID();
-      const fileType = fileName.split('.').pop()?.toLowerCase() || 'unknown';
-      const statementResult = await createBankStatement({ id: batchId, filename: fileName, file_type: fileType, total_records: newExpenses.length });
-      if (statementResult.error) {
-        showToast(`Ошибка создания записи о выписке: ${statementResult.error}`, 'error');
-        return false;
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isReviewProcessing, setIsReviewProcessing] = useState(false)
+
+  const saveExpensesBatch = useCallback(
+    async (rows: BulkExpenseRowData[], stats?: BuildExpensesResult['stats']) => {
+      let batchId: string | undefined
+
+      if (fileName) {
+        batchId = crypto.randomUUID()
+        const fileType = fileName.split('.').pop()?.toLowerCase() || 'unknown'
+
+        const statementResult = await createBankStatement({
+          id: batchId,
+          filename: fileName,
+          file_type: fileType,
+          total_records: rows.length
+        })
+
+        if (statementResult.error) {
+          showToast(`Ошибка создания записи о выписке: ${statementResult.error}`, 'error')
+          return false
+        }
       }
-    }
 
-    const expensesToCreate: CreateExpenseData[] = newExpenses.map((expense: BulkExpenseRowData) => ({ amount: expense.amount, description: expense.description, notes: expense.notes, category_id: expense.category_id || undefined, expense_date: expense.expense_date, expense_time: expense.expense_time || null, city_id: expense.city_id || undefined, city_input: expense.city?.trim() || undefined, input_method: 'bulk_table' as const, batch_id: batchId }));
-    const resultAction = await createBulkExpenses(expensesToCreate);
+      const payload: CreateExpenseData[] = rows.map(expense => ({
+        amount: expense.amount,
+        description: expense.description,
+        notes: expense.notes,
+        category_id: expense.category_id || undefined,
+        expense_date: expense.expense_date,
+        expense_time: expense.expense_time || null,
+        city_id: expense.city_id || undefined,
+        city_input: expense.city?.trim() || undefined,
+        input_method: 'bulk_table',
+        batch_id: batchId
+      }))
 
-    if (resultAction.error) {
-      showToast(resultAction.error, 'error');
-      return false;
-    }
+      const result = await createBulkExpenses(payload)
 
-    if (resultAction.success && resultAction.stats) {
-      const { success, failed, uncategorized, total } = resultAction.stats;
-      let message = `Создано ${success} из ${total} расходов`;
-      if (failed > 0) message += `, ${failed} с ошибками`;
-      if (uncategorized > 0) message += `, ${uncategorized} без категории`;
-      showToast(message, success > 0 ? 'success' : 'error');
-      if (success > 0) {
-        clearForm();
-        if (autoRedirect) router.push('/expenses');
+      if (result.error) {
+        showToast(result.error, 'error')
+        return false
       }
-      return success > 0;
-    }
-    return false;
-  }, [showToast, autoRedirect, router, clearForm]);
+
+      if (result.success && result.stats) {
+        const { success, failed, uncategorized, total } = result.stats
+        let message = `Создано ${success} из ${total} расходов`
+        if (failed > 0) {
+          message += `, ${failed} с ошибками`
+        }
+        if (uncategorized > 0) {
+          message += `, ${uncategorized} без категории`
+        }
+        showToast(message, success > 0 ? 'success' : 'error')
+
+        if (success > 0 && stats) {
+          const details: string[] = []
+          if (stats.autoDetectedCities > 0) {
+            details.push(`автогорода: ${stats.autoDetectedCities}`)
+          }
+          if (stats.manualTimes + stats.detectedTimes > 0) {
+            details.push(`время: ${stats.manualTimes + stats.detectedTimes}`)
+          }
+          if (details.length > 0) {
+            showToast(`Автозаполненные поля сохранены (${details.join(', ')}). Проверьте их в списке расходов.`, 'info')
+          }
+        }
+
+        return success > 0
+      }
+
+      return false
+    },
+    [fileName, showToast]
+  )
 
   const handleDirectSave = useCallback(async () => {
     if (expenses.length === 0) {
-      showToast('Добавьте хотя бы один расход', 'error');
-      return;
+      showToast('Добавьте хотя бы один расход', 'error')
+      return
     }
+
     if (!validateExpenses()) {
-      showToast('Исправьте ошибки в данных', 'error');
-      return;
+      showToast('Исправьте ошибки в данных', 'error')
+      return
     }
-    setIsSubmitting(true);
-    try {
-      await saveImportedExpenses({ expenses, stats: {} });
-    } catch (error) {
-      showToast('Произошла ошибка при сохранении', 'error');
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [expenses, validateExpenses, showToast, saveImportedExpenses]);
 
-  const handleReviewCancel = useCallback(() => {
-    setReviewModalState(null);
-    showToast('Сохранение отменено.', 'info');
-  }, [showToast]);
-
-  const handleReviewConfirm = useCallback(async () => {
-    if (!reviewModalState) return;
-    const resultToSave = reviewModalState.result;
-    setIsReviewProcessing(true);
+    setIsSubmitting(true)
     try {
-      const success = await saveImportedExpenses(resultToSave);
+      const success = await saveExpensesBatch(expenses)
       if (success) {
-        setReviewModalState(null);
+        clearExpenses()
+        resetFileState()
+        if (autoRedirect) {
+          router.push('/expenses')
+        }
       }
+    } catch (error) {
+      showToast('Произошла ошибка при сохранении', 'error')
     } finally {
-      setIsReviewProcessing(false);
+      setIsSubmitting(false)
     }
-  }, [reviewModalState, saveImportedExpenses]);
+  }, [autoRedirect, clearExpenses, expenses, resetFileState, router, saveExpensesBatch, showToast, validateExpenses])
+
+  const saveImportedExpenses = useCallback(
+    async (result: BuildExpensesResult) => {
+      setIsReviewProcessing(true)
+      try {
+        const success = await saveExpensesBatch(result.expenses, result.stats)
+        if (success) {
+          onDatasetSaved(result)
+          if (autoRedirect) {
+            router.push('/expenses')
+          }
+        }
+        return success
+      } finally {
+        setIsReviewProcessing(false)
+      }
+    },
+    [autoRedirect, onDatasetSaved, router, saveExpensesBatch]
+  )
 
   return {
     isSubmitting,
-    reviewModalState,
-    setReviewModalState,
     isReviewProcessing,
     handleDirectSave,
-    handleReviewCancel,
-    handleReviewConfirm,
     saveImportedExpenses
-  };
+  }
 }
-

--- a/src/components/expense-input/bulk-input/useFileHandler.ts
+++ b/src/components/expense-input/bulk-input/useFileHandler.ts
@@ -1,297 +1,329 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react';
-import { useToast } from '@/hooks/useToast';
+import { useState, useCallback, useRef } from 'react'
+import { useToast } from '@/hooks/useToast'
 import {
   parseBankStatementFile,
   analyzeHTML,
   parseCSV,
   parseHTML,
-  prepareParsedDataset
-} from '@/lib/utils/bankStatementParsers';
-import type { TableInfo } from '@/lib/utils/bankStatementParsers';
-import type { ParsedBankData } from '@/types';
-
-// Типы, которые должны быть доступны и в хуке, и в основном компоненте
-type SelectedTableMeta = Pick<
-  TableInfo,
-  'index' | 'description' | 'rowCount' | 'columnCount' | 'hasHeaders'
->
+  prepareParsedDataset,
+  type TableInfo
+} from '@/lib/utils/bankStatementParsers'
+import type { ParsedBankData } from '@/types'
+import type { SelectedTableMeta } from './types'
 
 interface UseFileHandlerProps {
-  appendSingleColumnExpenses: (rows: string[][], hasHeader: boolean, sourceLabel: string) => number;
-  setPastedData: (data: string[][]) => void;
-  setHasHeaderRow: (hasHeader: boolean) => void;
-  setIsColumnMappingOpen: (isOpen: boolean) => void;
-  setIsEditingColumnMapping: (isEditing: boolean) => void;
+  appendSingleColumnExpenses: (rows: string[][], hasHeader: boolean, sourceLabel: string) => number
+  onDatasetReady: (data: string[][], hasHeader: boolean) => void
+  resetDataset: () => void
+  setIsColumnMappingOpen: (isOpen: boolean) => void
+  setIsEditingColumnMapping: (value: boolean) => void
 }
 
-export function useFileHandler({ 
-  appendSingleColumnExpenses, 
-  setPastedData, 
-  setHasHeaderRow, 
-  setIsColumnMappingOpen, 
+export function useFileHandler({
+  appendSingleColumnExpenses,
+  onDatasetReady,
+  resetDataset,
+  setIsColumnMappingOpen,
   setIsEditingColumnMapping
 }: UseFileHandlerProps) {
-  const { showToast } = useToast();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { showToast } = useToast()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const [isFileLoading, setIsFileLoading] = useState(false);
-  const [fileName, setFileName] = useState<string>('');
-  const [fileContent, setFileContent] = useState<string | null>(null);
-  
-  const [availableTables, setAvailableTables] = useState<TableInfo[]>([]);
-  const [showTableSelection, setShowTableSelection] = useState(false);
-  const [selectedTableMeta, setSelectedTableMeta] = useState<SelectedTableMeta | null>(null);
-  const [savedTableIndex, setSavedTableIndex] = useState<number | null>(null);
+  const [isFileLoading, setIsFileLoading] = useState(false)
+  const [fileName, setFileName] = useState('')
+  const [fileContent, setFileContent] = useState<string | null>(null)
 
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
-  const [previewedTable, setPreviewedTable] = useState<{ description: string; rows: string[][] } | null>(null);
+  const [availableTables, setAvailableTables] = useState<TableInfo[]>([])
+  const [showTableSelection, setShowTableSelection] = useState(false)
+  const [selectedTableMeta, setSelectedTableMeta] = useState<SelectedTableMeta | null>(null)
+  const [savedTableIndex, setSavedTableIndex] = useState<number | null>(null)
+
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false)
+  const [previewedTable, setPreviewedTable] = useState<{ description: string; rows: string[][] } | null>(null)
 
   const loadSavedTableIndex = useCallback(() => {
     try {
-      const saved = localStorage.getItem('bulkExpenseTableIndex');
+      const saved = localStorage.getItem('bulkExpenseTableIndex')
       if (saved) {
-        const tableIndex = parseInt(saved, 10);
-        setSavedTableIndex(tableIndex);
-        return tableIndex;
+        const tableIndex = parseInt(saved, 10)
+        setSavedTableIndex(tableIndex)
+        return tableIndex
       }
-    } catch (error) { console.warn('Ошибка загрузки сохраненного индекса таблицы:', error); }
-    return null;
-  }, []);
+    } catch (error) {
+      console.warn('Ошибка загрузки сохраненного индекса таблицы:', error)
+    }
+    return null
+  }, [])
 
   const saveTableIndex = useCallback((tableIndex: number) => {
     try {
-      localStorage.setItem('bulkExpenseTableIndex', tableIndex.toString());
-      setSavedTableIndex(tableIndex);
-    } catch (error) { console.warn('Ошибка сохранения индекса таблицы:', error); }
-  }, []);
+      localStorage.setItem('bulkExpenseTableIndex', tableIndex.toString())
+      setSavedTableIndex(tableIndex)
+    } catch (error) {
+      console.warn('Ошибка сохранения индекса таблицы:', error)
+    }
+  }, [])
 
   const clearSavedTableIndex = useCallback(() => {
     try {
-      localStorage.removeItem('bulkExpenseTableIndex');
-      setSavedTableIndex(null);
-      setSelectedTableMeta(null);
-    } catch (error) { console.warn('Ошибка очистки индекса таблицы:', error); }
-  }, []);
+      localStorage.removeItem('bulkExpenseTableIndex')
+      setSavedTableIndex(null)
+      setSelectedTableMeta(null)
+    } catch (error) {
+      console.warn('Ошибка очистки индекса таблицы:', error)
+    }
+  }, [])
 
   const processTableSelection = useCallback(
     async (tableIndex: number, currentFileContent: string, currentFileName: string, tableInfo?: TableInfo) => {
-      setIsFileLoading(true);
-      saveTableIndex(tableIndex);
+      setIsFileLoading(true)
+      saveTableIndex(tableIndex)
 
-      const resolvedInfo = tableInfo ?? availableTables.find(table => table.index === tableIndex) ?? availableTables[tableIndex];
+      const resolvedInfo =
+        tableInfo ?? availableTables.find(table => table.index === tableIndex) ?? availableTables[tableIndex]
+
       if (resolvedInfo) {
-        setSelectedTableMeta({ ...resolvedInfo });
+        setSelectedTableMeta({
+          index: resolvedInfo.index,
+          description: resolvedInfo.description,
+          rowCount: resolvedInfo.rowCount,
+          columnCount: resolvedInfo.columnCount,
+          hasHeaders: resolvedInfo.hasHeaders
+        })
       }
 
       try {
-        const parsed = await parseBankStatementFile(new File([currentFileContent], currentFileName), tableIndex);
-        const prepared = prepareParsedDataset(parsed);
-        const dataset = prepared.rows;
+        const parsed = await parseBankStatementFile(new File([currentFileContent], currentFileName), tableIndex)
+        const prepared = prepareParsedDataset(parsed)
+        const dataset = prepared.rows
 
         if (dataset.length === 0) {
-          showToast('Выбранная таблица не содержит данных', 'error');
-          return;
+          showToast('Выбранная таблица не содержит данных', 'error')
+          return
         }
 
-        const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset;
+        const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
         if (dataRows.length === 0) {
-          showToast('Выбранная таблица содержит только заголовки', 'warning');
-          return;
+          showToast('Выбранная таблица содержит только заголовки', 'warning')
+          return
         }
 
         if (dataRows[0].length > 1) {
-          setPastedData(dataset);
-          setHasHeaderRow(prepared.hasHeader);
-          setIsEditingColumnMapping(false);
-          setIsColumnMappingOpen(true);
-          showToast(`Загружено ${dataRows.length} строк из выбранной таблицы`, 'success');
+          onDatasetReady(dataset, prepared.hasHeader)
+          setIsEditingColumnMapping(false)
+          setIsColumnMappingOpen(true)
+          showToast(`Загружено ${dataRows.length} строк из выбранной таблицы`, 'success')
         } else {
-          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'выбранной таблицы');
-          setHasHeaderRow(false);
+          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'выбранной таблицы')
         }
       } catch (error) {
-        showToast(error instanceof Error ? error.message : 'Ошибка обработки таблицы', 'error');
+        showToast(error instanceof Error ? error.message : 'Ошибка обработки таблицы', 'error')
       } finally {
-        setShowTableSelection(false);
-        setIsFileLoading(false);
+        setShowTableSelection(false)
+        setIsFileLoading(false)
       }
     },
-    [appendSingleColumnExpenses, availableTables, saveTableIndex, showToast, setPastedData, setHasHeaderRow, setIsEditingColumnMapping, setIsColumnMappingOpen]
-  );
+    [appendSingleColumnExpenses, availableTables, onDatasetReady, saveTableIndex, setIsColumnMappingOpen, setIsEditingColumnMapping, showToast]
+  )
 
-  const handleTableSelection = useCallback(async (tableIndex: number, tableInfo?: TableInfo) => {
-    if (!fileContent || !fileName) {
-      showToast('Сначала загрузите файл с выпиской', 'error');
-      return;
-    }
-    await processTableSelection(tableIndex, fileContent, fileName, tableInfo);
-  }, [fileContent, fileName, processTableSelection, showToast]);
+  const handleTableSelection = useCallback(
+    async (tableIndex: number, tableInfo?: TableInfo) => {
+      if (!fileContent || !fileName) {
+        showToast('Сначала загрузите файл с выпиской', 'error')
+        return
+      }
+      await processTableSelection(tableIndex, fileContent, fileName, tableInfo)
+    },
+    [fileContent, fileName, processTableSelection, showToast]
+  )
 
-  const handleFileUpload = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+  const openDatasetFromParsed = useCallback(
+    (parsed: ParsedBankData, sourceLabel: string) => {
+      const prepared = prepareParsedDataset(parsed)
+      const dataset = prepared.rows
 
-    setIsFileLoading(true);
-    try {
-      const fileText = await file.text();
-      setFileName(file.name);
-      setFileContent(fileText);
-      setSelectedTableMeta(null);
-      setAvailableTables([]);
+      if (dataset.length === 0) {
+        showToast(`${sourceLabel} пуст`, 'error')
+        return false
+      }
 
-      const fileExtension = file.name.split('.').pop()?.toLowerCase();
+      const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset
+      if (dataRows.length === 0) {
+        showToast(`${sourceLabel} содержит только заголовки`, 'warning')
+        return false
+      }
 
-      if (fileExtension === 'pdf') {
-        // PDF logic remains here for now due to API call
-      } else if (fileExtension === 'html' || fileExtension === 'htm') {
-        const analysis = analyzeHTML(fileText);
-        if (analysis.tables.length === 0) {
-          showToast('В HTML файле не найдено таблиц с данными', 'error');
-          setIsFileLoading(false);
-          return;
-        }
-        setAvailableTables(analysis.tables);
-        if (analysis.tables.length === 1) {
-          await processTableSelection(0, fileText, file.name, analysis.tables[0]);
-        } else {
-          const savedIdx = loadSavedTableIndex();
-          if (savedIdx !== null && savedIdx >= 0 && savedIdx < analysis.tables.length) {
-            await processTableSelection(savedIdx, fileText, file.name, analysis.tables[savedIdx]);
+      if (dataRows[0].length > 1) {
+        onDatasetReady(dataset, prepared.hasHeader)
+        setIsEditingColumnMapping(false)
+        setIsColumnMappingOpen(true)
+        const label = sourceLabel.startsWith('вставлен') ? 'вставленные данные' : sourceLabel
+        showToast(`Получены ${dataRows.length} строк из ${label}. Проверьте соответствие столбцов.`, 'success')
+      } else {
+        appendSingleColumnExpenses(dataset, prepared.hasHeader, sourceLabel)
+      }
+
+      return true
+    },
+    [appendSingleColumnExpenses, onDatasetReady, setIsColumnMappingOpen, setIsEditingColumnMapping, showToast]
+  )
+
+  const handleFileUpload = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      if (!file) return
+
+      setIsFileLoading(true)
+      try {
+        const fileText = await file.text()
+        setFileName(file.name)
+        setFileContent(fileText)
+        setSelectedTableMeta(null)
+        setAvailableTables([])
+
+        const fileExtension = file.name.split('.').pop()?.toLowerCase()
+
+        if (fileExtension === 'html' || fileExtension === 'htm') {
+          const analysis = analyzeHTML(fileText)
+          if (analysis.tables.length === 0) {
+            showToast('В HTML файле не найдено таблиц с данными', 'error')
+            setIsFileLoading(false)
+            return
+          }
+
+          setAvailableTables(analysis.tables)
+          if (analysis.tables.length === 1) {
+            await processTableSelection(0, fileText, file.name, analysis.tables[0])
           } else {
-            setShowTableSelection(true);
-            setIsFileLoading(false);
+            const savedIdx = loadSavedTableIndex()
+            if (savedIdx !== null && savedIdx >= 0 && savedIdx < analysis.tables.length) {
+              await processTableSelection(savedIdx, fileText, file.name, analysis.tables[savedIdx])
+            } else {
+              setShowTableSelection(true)
+              setIsFileLoading(false)
+            }
+          }
+          return
+        }
+
+        const parsed = await parseBankStatementFile(file)
+        openDatasetFromParsed(parsed, 'файла')
+      } catch (error) {
+        showToast('Ошибка при загрузке файла', 'error')
+      } finally {
+        setIsFileLoading(false)
+        if (fileInputRef.current) {
+          fileInputRef.current.value = ''
+        }
+      }
+    },
+    [
+      loadSavedTableIndex,
+      openDatasetFromParsed,
+      processTableSelection,
+      showToast
+    ]
+  )
+
+  const handlePaste = useCallback(
+    async (event: React.ClipboardEvent) => {
+      event.preventDefault()
+
+      setSelectedTableMeta(null)
+      setAvailableTables([])
+      setFileContent(null)
+      setFileName('')
+      resetDataset()
+
+      try {
+        const htmlData = event.clipboardData.getData('text/html')
+        if (htmlData && htmlData.includes('<table')) {
+          try {
+            const parsedFromHtml = parseHTML(htmlData)
+            if (openDatasetFromParsed(parsedFromHtml, 'вставленной таблицы')) {
+              return
+            }
+          } catch (htmlError) {
+            console.warn('Не удалось обработать HTML из буфера обмена', htmlError)
           }
         }
-      } else {
-        const parsed = await parseBankStatementFile(file);
-        const prepared = prepareParsedDataset(parsed);
-        const dataset = prepared.rows;
-        if (dataset.length === 0) {
-          showToast('Файл пуст', 'error');
-          setIsFileLoading(false);
-          return;
+
+        const pastedText = event.clipboardData.getData('text')
+        if (!pastedText) {
+          showToast('Буфер обмена пуст', 'warning')
+          return
         }
-        const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset;
-        if (dataRows.length === 0) {
-          showToast('В файле найдены только заголовки без данных', 'warning');
-          setIsFileLoading(false);
-          return;
-        }
-        if (dataRows[0].length > 1) {
-          setPastedData(dataset);
-          setHasHeaderRow(prepared.hasHeader);
-          setIsEditingColumnMapping(false);
-          setIsColumnMappingOpen(true);
-          showToast(`Загружено ${dataRows.length} строк из файла`, 'success');
-        } else {
-          appendSingleColumnExpenses(dataset, prepared.hasHeader, 'файла');
-          setHasHeaderRow(false);
-        }
-        setIsFileLoading(false);
+
+        const parsed = parseCSV(pastedText)
+        openDatasetFromParsed(parsed, 'буфера обмена')
+      } catch (error) {
+        console.error('Ошибка при вставке данных', error)
+        showToast('Ошибка при вставке данных', 'error')
       }
-    } catch (error) {
-      showToast('Ошибка при загрузке файла', 'error');
-      setIsFileLoading(false);
-    } finally {
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
+    },
+    [openDatasetFromParsed, resetDataset, showToast]
+  )
+
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault()
+      setIsDragOver(false)
+      const files = event.dataTransfer.files
+      if (files && files.length > 0) {
+        const syntheticEvent = { target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>
+        void handleFileUpload(syntheticEvent)
       }
-    }
-  }, [showToast, processTableSelection, loadSavedTableIndex, appendSingleColumnExpenses, setPastedData, setHasHeaderRow, setIsColumnMappingOpen, setIsEditingColumnMapping]);
+    },
+    [handleFileUpload]
+  )
 
-  const handlePaste = useCallback(async (event: React.ClipboardEvent) => {
-    event.preventDefault();
-    showToast('Paste event triggered', 'info');
+  const handlePreviewTable = useCallback(
+    (tableIndex: number) => {
+      if (!fileContent) return
 
-    const files = event.clipboardData.files;
-    if (files && files.length > 0) {
-      showToast(`Found ${files.length} file(s) in clipboard.`, 'info');
-      const syntheticEvent = { target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>;
-      handleFileUpload(syntheticEvent);
-      return;
-    }
+      try {
+        const parsedTable = parseHTML(fileContent, tableIndex)
+        const allRows = parsedTable.headers && parsedTable.headers.length > 0
+          ? [parsedTable.headers, ...parsedTable.rows]
+          : parsedTable.rows
 
-    showToast('No files in clipboard, processing as text.', 'info');
-    setSelectedTableMeta(null);
-    setAvailableTables([]);
-    setFileContent(null);
-    setFileName('');
-
-    try {
-      const pastedText = event.clipboardData.getData('text');
-      if (!pastedText) {
-        showToast('Буфер обмена пуст', 'warning');
-        return;
+        setPreviewedTable({
+          description: availableTables[tableIndex]?.description || `Таблица ${tableIndex + 1}`,
+          rows: allRows
+        })
+        setIsPreviewModalOpen(true)
+      } catch (error) {
+        console.error('Ошибка предпросмотра таблицы', error)
+        showToast('Не удалось загрузить предпросмотр таблицы', 'error')
       }
-      const parsed = parseCSV(pastedText);
-      const prepared = prepareParsedDataset(parsed);
-      const dataset = prepared.rows;
-      if (dataset.length === 0) {
-        showToast('Вставленные данные пусты', 'error');
-        return;
-      }
-      const dataRows = prepared.hasHeader ? dataset.slice(1) : dataset;
-      if (dataRows.length === 0) {
-        showToast('Не найдены строки с данными', 'error');
-        return;
-      }
-      if (dataRows[0].length > 1) {
-        setPastedData(dataset);
-        setHasHeaderRow(prepared.hasHeader);
-        setIsEditingColumnMapping(false);
-        setIsColumnMappingOpen(true);
-        showToast(`Получены данные (${dataRows.length} строк). Проверьте соответствие столбцов.`, 'success');
-      } else {
-        appendSingleColumnExpenses(dataset, prepared.hasHeader, 'буфера обмена');
-        setHasHeaderRow(false);
-      }
-    } catch (error) {
-      console.error('Ошибка при вставке данных', error);
-      showToast('Ошибка при вставке данных', 'error');
-    }
-  }, [showToast, appendSingleColumnExpenses, setPastedData, setHasHeaderRow, setIsColumnMappingOpen, setIsEditingColumnMapping, handleFileUpload]);
+    },
+    [availableTables, fileContent, showToast]
+  )
 
-  const handleDragOver = useCallback((event: React.DragEvent) => { event.preventDefault(); setIsDragOver(true); }, []);
-  const handleDragLeave = useCallback((event: React.DragEvent) => { event.preventDefault(); setIsDragOver(false); }, []);
-  const handleDrop = useCallback((event: React.DragEvent) => {
-    event.preventDefault();
-    setIsDragOver(false);
-    const files = event.dataTransfer.files;
-    if (files && files.length > 0) {
-      const syntheticEvent = { target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>;
-      handleFileUpload(syntheticEvent);
-    }
-  }, [handleFileUpload]);
-
-  const handlePreviewTable = (tableIndex: number) => {
-    if (!fileContent) return;
-    try {
-      const parsedTable = parseHTML(fileContent, tableIndex);
-      const allRows = parsedTable.headers && parsedTable.headers.length > 0 
-        ? [parsedTable.headers, ...parsedTable.rows] 
-        : parsedTable.rows;
-      setPreviewedTable({ description: availableTables[tableIndex]?.description || `Таблица ${tableIndex + 1}`, rows: allRows });
-      setIsPreviewModalOpen(true);
-    } catch (error) {
-      console.error("Error previewing table:", error);
-      showToast("Не удалось загрузить предпросмотр таблицы", "error");
-    }
-  };
-
-  const handleClear = useCallback(() => {
-    setFileName('');
-    setFileContent(null);
-    setAvailableTables([]);
-    setShowTableSelection(false);
-    setSelectedTableMeta(null);
-    setIsDragOver(false);
+  const handleFileStateReset = useCallback(() => {
+    setFileName('')
+    setFileContent(null)
+    setAvailableTables([])
+    setShowTableSelection(false)
+    setSelectedTableMeta(null)
+    setIsDragOver(false)
     if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      fileInputRef.current.value = ''
     }
-  }, []);
+  }, [])
 
   return {
     fileInputRef,
@@ -316,6 +348,6 @@ export function useFileHandler({
     handleDrop,
     handleTableSelection,
     handlePreviewTable,
-    handleClear
-  };
+    handleFileStateReset
+  }
 }

--- a/src/components/expense-input/bulk-input/utils/columnMapping.ts
+++ b/src/components/expense-input/bulk-input/utils/columnMapping.ts
@@ -1,0 +1,70 @@
+import type { ColumnMapping, ColumnMappingField } from '@/types'
+
+const COLUMN_MAPPING_FIELDS: ColumnMappingField[] = [
+  'amount',
+  'description',
+  'city',
+  'expense_date',
+  'expense_time',
+  'notes'
+]
+
+const COLUMN_MAPPING_FIELD_SET = new Set<ColumnMappingField>(COLUMN_MAPPING_FIELDS)
+
+export function isColumnMappingField(value: unknown): value is ColumnMappingField {
+  return typeof value === 'string' && COLUMN_MAPPING_FIELD_SET.has(value as ColumnMappingField)
+}
+
+export function normalizeColumnMapping(raw: unknown): ColumnMapping[] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+
+  return raw.map((item, index) => {
+    const candidate = item as Partial<ColumnMapping> & { targetField?: unknown }
+
+    const directTargets = Array.isArray(candidate?.targetFields)
+      ? candidate.targetFields.filter(isColumnMappingField)
+      : []
+
+    const legacyTarget = isColumnMappingField(candidate?.targetField)
+      ? [candidate.targetField]
+      : []
+
+    const combinedTargets = [...directTargets, ...legacyTarget]
+    const uniqueTargets = Array.from(new Set(combinedTargets))
+
+    const normalizedTargets = uniqueTargets.filter(isColumnMappingField)
+
+    const normalizedEnabled = typeof candidate?.enabled === 'boolean'
+      ? candidate.enabled && normalizedTargets.length > 0
+      : normalizedTargets.length > 0
+
+    return {
+      sourceIndex: typeof candidate?.sourceIndex === 'number' ? candidate.sourceIndex : index,
+      targetFields: normalizedEnabled ? normalizedTargets : [],
+      enabled: normalizedEnabled && normalizedTargets.length > 0,
+      preview: typeof candidate?.preview === 'string' ? candidate.preview : '',
+      hidden: Boolean(candidate?.hidden)
+    }
+  })
+}
+
+export function sanitizeColumnMapping(mapping: ColumnMapping[]): ColumnMapping[] {
+  return normalizeColumnMapping(mapping)
+}
+
+export function getColumnLabel(index: number, headerRow?: string[] | null): string {
+  const headerValue = headerRow?.[index]?.trim()
+  if (headerValue) {
+    return headerValue
+  }
+
+  if (index >= 0 && index < 26) {
+    return `Столбец ${String.fromCharCode(65 + index)}`
+  }
+
+  return `Столбец ${index + 1}`
+}
+
+export const COLUMN_MAPPING_STORAGE_KEY = 'bulkExpenseColumnMapping'


### PR DESCRIPTION
## Summary
- refactor the bulk expense input container into composable hooks and smaller UI components
- add shared utility helpers and types for column mapping and review flows
- redesign the column mapping modal to offer a simpler mapping experience and better summaries

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec3a00530c8327b7958442689b6941